### PR TITLE
fix: add permissions block for reusable workflow

### DIFF
--- a/.github/workflows/composer-deploy-dags.yaml
+++ b/.github/workflows/composer-deploy-dags.yaml
@@ -11,6 +11,10 @@ on:
       - 'dags/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   deploy:
     uses: destaquesgovbr/reusable-workflows/.github/workflows/composer-deploy-dags.yml@v1


### PR DESCRIPTION
## Summary
- Add `permissions: contents: read, id-token: write` at workflow level
- Required because reusable workflows inherit permissions from the caller

## Context
Follow-up to #2 — the deploy was failing with `startup_failure` because the caller didn't grant `id-token: write` needed for WIF authentication in the reusable workflow.