### PR TITLE
refactor: unify manager patterns and remove duplicated code

### DIFF
--- a/src/govbr_scraper/scrapers/ebc_scrape_manager.py
+++ b/src/govbr_scraper/scrapers/ebc_scrape_manager.py
@@ -1,12 +1,11 @@
 import hashlib
 import logging
-import os
 from collections import OrderedDict
 from datetime import date, datetime
 from typing import Any, Dict, List
 
 from govbr_scraper.scrapers.ebc_webscraper import EBCWebScraper
-from govbr_scraper.scrapers.yaml_config import load_urls_from_yaml
+from govbr_scraper.scrapers.yaml_config import get_config_dir, load_urls_from_yaml
 
 # Set up logging configuration
 logging.basicConfig(
@@ -39,10 +38,6 @@ class EBCScrapeManager:
         """
         self.dataset_manager = storage  # Keep attribute name for compatibility
 
-    def _get_config_dir(self) -> str:
-        """Get the config directory path."""
-        return os.path.join(os.path.dirname(os.path.abspath(__file__)), "config")
-
     def run_scraper(
         self,
         min_date: str,
@@ -68,7 +63,7 @@ class EBCScrapeManager:
 
         try:
             agency_urls = {}
-            config_dir = self._get_config_dir()
+            config_dir = get_config_dir(__file__)
             # Load URLs for each agency in the list
             if agencies:
                 for agency in agencies:

--- a/src/govbr_scraper/scrapers/yaml_config.py
+++ b/src/govbr_scraper/scrapers/yaml_config.py
@@ -8,6 +8,16 @@ from typing import Any, Dict
 import yaml
 
 
+def get_config_dir(module_file: str) -> str:
+    """
+    Get the config directory path relative to a module file.
+
+    :param module_file: The __file__ of the calling module.
+    :return: Absolute path to the config directory.
+    """
+    return os.path.join(os.path.dirname(os.path.abspath(module_file)), "config")
+
+
 def load_urls_from_yaml(
     config_dir: str, file_name: str, agency: str = None
 ) -> Dict[str, str]:

--- a/tests/unit/test_scrape_manager.py
+++ b/tests/unit/test_scrape_manager.py
@@ -1,7 +1,0 @@
-"""
-Tests for ScrapeManager.
-
-Note: Tests for YAML config loading functions (extract_url, is_agency_inactive,
-load_urls_from_yaml) have been moved to test_yaml_config.py since these functions
-are now in the shared yaml_config module.
-"""

--- a/tests/unit/test_yaml_config.py
+++ b/tests/unit/test_yaml_config.py
@@ -4,23 +4,36 @@ Tests for yaml_config module - shared utilities for loading agency YAML configur
 import os
 import pytest
 from govbr_scraper.scrapers.yaml_config import (
+    get_config_dir,
     load_urls_from_yaml,
     extract_url,
     is_agency_inactive,
 )
 
+# Path to the scrapers module, used to resolve config dir in tests
+_SCRAPERS_MODULE = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "..",
+    "..",
+    "src",
+    "govbr_scraper",
+    "scrapers",
+    "scrape_manager.py",
+)
 
-def get_config_dir():
-    """Get the config directory path for tests."""
-    return os.path.join(
-        os.path.dirname(os.path.abspath(__file__)),
-        "..",
-        "..",
-        "src",
-        "govbr_scraper",
-        "scrapers",
-        "config",
-    )
+
+class TestGetConfigDir:
+    """Tests for get_config_dir function."""
+
+    def test_returns_config_subdir(self):
+        """get_config_dir should return a path ending in 'config'."""
+        config_dir = get_config_dir(_SCRAPERS_MODULE)
+        assert config_dir.endswith("config")
+
+    def test_config_dir_exists(self):
+        """get_config_dir should return an existing directory."""
+        config_dir = get_config_dir(_SCRAPERS_MODULE)
+        assert os.path.isdir(config_dir)
 
 
 class TestExtractUrl:
@@ -75,14 +88,14 @@ class TestLoadUrlsFromYamlGovBr:
 
     def test_load_urls_returns_dict(self):
         """load_urls_from_yaml should return a dict mapping agency names to URLs."""
-        config_dir = get_config_dir()
+        config_dir = get_config_dir(_SCRAPERS_MODULE)
         agency_urls = load_urls_from_yaml(config_dir, "site_urls.yaml")
         assert isinstance(agency_urls, dict)
         assert len(agency_urls) > 0
 
     def test_load_urls_filters_inactive(self):
         """Inactive agencies should not be in the returned dict."""
-        config_dir = get_config_dir()
+        config_dir = get_config_dir(_SCRAPERS_MODULE)
         agency_urls = load_urls_from_yaml(config_dir, "site_urls.yaml")
         # cisc uses the generic gov.br/pt-br/noticias URL and is inactive
         for agency_name, url in agency_urls.items():
@@ -90,7 +103,7 @@ class TestLoadUrlsFromYamlGovBr:
 
     def test_load_specific_active_agency(self):
         """Loading a specific active agency should work."""
-        config_dir = get_config_dir()
+        config_dir = get_config_dir(_SCRAPERS_MODULE)
         agency_urls = load_urls_from_yaml(config_dir, "site_urls.yaml", agency="mec")
         assert len(agency_urls) == 1
         assert "mec" in agency_urls
@@ -98,13 +111,13 @@ class TestLoadUrlsFromYamlGovBr:
 
     def test_load_specific_inactive_agency_raises(self):
         """Loading a specific inactive agency should raise ValueError."""
-        config_dir = get_config_dir()
+        config_dir = get_config_dir(_SCRAPERS_MODULE)
         with pytest.raises(ValueError, match="inactive"):
             load_urls_from_yaml(config_dir, "site_urls.yaml", agency="cisc")
 
     def test_load_nonexistent_agency_raises(self):
         """Loading a nonexistent agency should raise ValueError."""
-        config_dir = get_config_dir()
+        config_dir = get_config_dir(_SCRAPERS_MODULE)
         with pytest.raises(ValueError, match="not found"):
             load_urls_from_yaml(config_dir, "site_urls.yaml", agency="nonexistent_agency_xyz")
 
@@ -114,14 +127,14 @@ class TestLoadUrlsFromYamlEBC:
 
     def test_load_urls_returns_dict(self):
         """load_urls_from_yaml should return a dict mapping agency names to URLs."""
-        config_dir = get_config_dir()
+        config_dir = get_config_dir(_SCRAPERS_MODULE)
         agency_urls = load_urls_from_yaml(config_dir, "ebc_urls.yaml")
         assert isinstance(agency_urls, dict)
         assert len(agency_urls) > 0
 
     def test_load_urls_filters_inactive(self):
         """Inactive agencies should not be in the returned dict."""
-        config_dir = get_config_dir()
+        config_dir = get_config_dir(_SCRAPERS_MODULE)
         agency_urls = load_urls_from_yaml(config_dir, "ebc_urls.yaml")
         # memoria-ebc is inactive, so its URL should not be present
         for agency_name, url in agency_urls.items():
@@ -129,7 +142,7 @@ class TestLoadUrlsFromYamlEBC:
 
     def test_load_urls_includes_active_agencies(self):
         """Active agencies should be in the returned dict."""
-        config_dir = get_config_dir()
+        config_dir = get_config_dir(_SCRAPERS_MODULE)
         agency_urls = load_urls_from_yaml(config_dir, "ebc_urls.yaml")
         urls_str = " ".join(agency_urls.values())
         # agencia_brasil and tvbrasil are active
@@ -137,7 +150,7 @@ class TestLoadUrlsFromYamlEBC:
 
     def test_load_specific_active_agency(self):
         """Loading a specific active agency should work."""
-        config_dir = get_config_dir()
+        config_dir = get_config_dir(_SCRAPERS_MODULE)
         agency_urls = load_urls_from_yaml(config_dir, "ebc_urls.yaml", agency="agencia_brasil")
         assert len(agency_urls) == 1
         assert "agencia_brasil" in agency_urls
@@ -145,12 +158,12 @@ class TestLoadUrlsFromYamlEBC:
 
     def test_load_specific_inactive_agency_raises(self):
         """Loading a specific inactive agency should raise ValueError."""
-        config_dir = get_config_dir()
+        config_dir = get_config_dir(_SCRAPERS_MODULE)
         with pytest.raises(ValueError, match="inactive"):
             load_urls_from_yaml(config_dir, "ebc_urls.yaml", agency="memoria-ebc")
 
     def test_load_nonexistent_agency_raises(self):
         """Loading a nonexistent agency should raise ValueError."""
-        config_dir = get_config_dir()
+        config_dir = get_config_dir(_SCRAPERS_MODULE)
         with pytest.raises(ValueError, match="not found"):
             load_urls_from_yaml(config_dir, "ebc_urls.yaml", agency="nonexistent_agency_xyz")


### PR DESCRIPTION
## Summary

Follow-up do PR #4 para resolver inconsistências identificadas na revisão:

- **`ScrapeManager` agora usa tuplas `(agency_name, scraper)`** como `EBCScrapeManager`, garantindo que `agencies_processed` retorne nomes das chaves YAML de forma consistente em ambos os endpoints
- **`get_config_dir()` extraído para `yaml_config.py`**, removendo duplicação de `_get_config_dir()` em ambos managers
- **`test_scrape_manager.py` vazio removido** (os testes foram movidos para `test_yaml_config.py` no commit anterior)
- **Testes adicionados** para `get_config_dir()`

## Arquivos modificados

| Arquivo | Mudança |
|---------|---------|
| `src/govbr_scraper/scrapers/yaml_config.py` | Adicionada `get_config_dir()` |
| `src/govbr_scraper/scrapers/scrape_manager.py` | Usa tuplas + importa `get_config_dir` |
| `src/govbr_scraper/scrapers/ebc_scrape_manager.py` | Importa `get_config_dir`, remove `_get_config_dir` |
| `tests/unit/test_scrape_manager.py` | Deletado (vazio) |
| `tests/unit/test_yaml_config.py` | Adicionados testes para `get_config_dir` |

## Test plan

- [x] `poetry run pytest tests/unit/ -v` — **31 testes passando**

🤖 Generated with [Claude Code](https://claude.com/claude-code)