### PR TITLE
cleanup: corrigir referências a HuggingFace em logs do scraper

### DIFF
--- a/src/govbr_scraper/scrapers/scrape_manager.py
+++ b/src/govbr_scraper/scrapers/scrape_manager.py
@@ -96,7 +96,7 @@ class ScrapeManager:
                         scraped_data = scraper.scrape_news()
                         if scraped_data:
                             logging.info(
-                                f"Appending news for {agency_name} to HF dataset."
+                                f"Appending news for {agency_name} to storage backend."
                             )
                             articles_scraped += len(scraped_data)
                             saved = self._process_and_upload_data(scraped_data, allow_update) or 0
@@ -130,7 +130,7 @@ class ScrapeManager:
                         logging.error(f"Unexpected error for {agency_name}: {e}")
 
                 if all_news_data:
-                    logging.info("Appending all collected news to HF dataset.")
+                    logging.info("Appending all collected news to storage backend.")
                     articles_scraped = len(all_news_data)
                     articles_saved = self._process_and_upload_data(all_news_data, allow_update) or 0
                 else:


### PR DESCRIPTION
## Summary

Migrado parcialmente do [PR #72](https://github.com/destaquesgovbr/data-platform/pull/72) do `data-platform` (apenas a parte que pertence ao scraper).

- Atualiza 2 mensagens de log no `scrape_manager.py` que diziam "HF dataset" quando os dados fluem via `StorageAdapter` → PostgreSQL

## Test plan

- [x] Mudança apenas em strings de log, sem impacto funcional
- [x] Verificado que `ebc_scrape_manager.py` já foi corrigido no PR #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)