### PR TITLE
feat: otimizar scraper com known URL fence

### DIFF
--- a/_plan/known-url-fence.md
+++ b/_plan/known-url-fence.md
@@ -1,0 +1,173 @@
+# Plano: Otimizar scraper com "known URL fence" — parar cedo sem depender de datetime
+
+## Contexto
+
+Hoje o scraper processa **todos os artigos do dia** na listagem, mesmo que já tenha coletado a maioria deles em execuções anteriores. Com DAGs rodando a cada 10 minutos, isso significa re-processar dezenas de artigos já conhecidos. O gargalo é o **fetch da página do artigo** (request HTTP + parse HTML), que acontece para cada item da listagem — mesmo duplicatas.
+
+A condição de parada atual depende de comparar **datas** (`datetime.date`) extraídas da listagem. Mas a listagem gov.br só tem data sem hora, então o scraper processa o dia inteiro até encontrar um artigo de um dia anterior.
+
+## Abordagem: "Known URL Fence"
+
+**Ideia:** Antes de iniciar o scraping, consultar o banco para obter as URLs de artigos recentes da agência. Usar esse conjunto como "cerca" durante a iteração:
+
+1. Se a URL do item na listagem **NÃO está** no conjunto → é novo → buscar página do artigo normalmente
+2. Se a URL **ESTÁ** no conjunto → pular o fetch (já temos esse artigo)
+3. Se encontrar **N consecutivos** conhecidos → **STOP** (tudo abaixo também é conhecido)
+
+### Vantagens sobre datetime
+
+| Aspecto | Datetime | Known URL Fence |
+|---------|----------|-----------------|
+| Depende de parsing de data | Sim | Não |
+| Lida com timezone | Precisa normalizar | N/A |
+| Artigo sem data | Não consegue parar | Para normalmente |
+| Artigo re-publicado | Pode reprocessar | Detecta pela URL |
+| Custo | Zero (não consulta DB) | 1 SELECT por agência |
+
+### Fluxo otimizado
+
+```
+1. ScrapeManager consulta DB: "URLs dos últimos 200 artigos da agência X"
+   → known_urls = {"https://gov.br/mec/noticia-a", "https://gov.br/mec/noticia-b", ...}
+
+2. WebScraper itera listagem:
+   Artigo 1: url=".../noticia-nova"  → NÃO conhecida → fetch + processo ✓
+   Artigo 2: url=".../noticia-b"     → CONHECIDA → skip (sem fetch)
+   Artigo 3: url=".../noticia-a"     → CONHECIDA (2 consecutivos)
+   Artigo 4: url=".../noticia-velha" → CONHECIDA (3 consecutivos) → STOP ■
+```
+
+### Limiar de parada (N=3)
+
+`N=3` consecutivos conhecidos é um bom default:
+- Protege contra o caso raro de uma notícia ser deletada e re-inserida (furo de 1)
+- Não espera demais (3 artigos = ~3 requests poupados no máximo)
+- Configurável caso precise ajustar
+
+## Ordem de implementação: testes primeiro (TDD)
+
+### Fase 1 — Testes (RED)
+
+Escrever testes que definem o comportamento esperado antes de implementar.
+
+#### `tests/unit/test_known_url_fence.py`
+
+Testes para a lógica do WebScraper com known_urls:
+
+1. **`test_new_article_is_processed`** — artigo com URL desconhecida é processado normalmente
+2. **`test_known_article_is_skipped`** — artigo com URL conhecida é pulado (sem fetch)
+3. **`test_consecutive_known_urls_stop`** — 3 consecutivos conhecidos → retorna False (stop)
+4. **`test_new_article_resets_consecutive_counter`** — artigo novo entre conhecidos reseta o contador
+5. **`test_empty_known_urls_processes_all`** — sem known_urls, comportamento idêntico ao atual
+6. **`test_known_url_below_threshold_continues`** — 1-2 conhecidos consecutivos → continua (return True)
+
+#### `tests/unit/test_postgres_manager_urls.py`
+
+Testes para `get_recent_urls`:
+
+1. **`test_get_recent_urls_returns_set`** — retorna set de strings
+2. **`test_get_recent_urls_filters_by_agency`** — só retorna URLs da agência especificada
+3. **`test_get_recent_urls_respects_limit`** — respeita o limite
+4. **`test_get_recent_urls_empty_for_unknown_agency`** — agência desconhecida retorna set vazio
+
+#### `tests/unit/test_api.py` (atualizar)
+
+5. **`test_scrape_agencies_passes_known_urls`** — verificar que ScrapeManager consulta URLs antes de scraping
+
+### Fase 2 — Implementação (GREEN)
+
+Implementar o código para fazer os testes passarem.
+
+#### 1. `src/govbr_scraper/storage/postgres_manager.py` — novo método
+
+```python
+def get_recent_urls(self, agency_key: str, limit: int = 200) -> set[str]:
+    """Retorna URLs dos artigos mais recentes de uma agência."""
+    query = """
+        SELECT url FROM news
+        WHERE agency_key = %s AND url IS NOT NULL
+        ORDER BY published_at DESC
+        LIMIT %s
+    """
+    conn = self.pool.getconn()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(query, (agency_key, limit))
+            return {row[0] for row in cur.fetchall()}
+    finally:
+        self.pool.putconn(conn)
+```
+
+#### 2. `src/govbr_scraper/storage/storage_adapter.py` — expor método
+
+```python
+def get_recent_urls(self, agency_key: str, limit: int = 200) -> set[str]:
+    """Retorna URLs recentes de uma agência para otimização de scraping."""
+    return self.postgres.get_recent_urls(agency_key, limit)
+```
+
+#### 3. `src/govbr_scraper/scrapers/scrape_manager.py` — consultar antes de scraping
+
+Alterar a criação de webscrapers para consultar URLs conhecidas:
+
+```python
+webscrapers = []
+for agency_name, url in agency_urls.items():
+    try:
+        known_urls = self.storage.get_recent_urls(agency_name)
+    except Exception:
+        known_urls = set()  # Fallback: sem otimização
+    webscrapers.append(
+        (agency_name, WebScraper(min_date, url, max_date=max_date, known_urls=known_urls))
+    )
+```
+
+#### 4. `src/govbr_scraper/scrapers/webscraper.py` — lógica de fence
+
+**Construtor** — aceitar `known_urls`:
+```python
+def __init__(self, min_date, base_url, max_date=None, known_urls=None):
+    # ... existente ...
+    self.known_urls = known_urls or set()
+    self._consecutive_known = 0
+    self.KNOWN_URL_STOP_THRESHOLD = 3
+```
+
+**`extract_news_info`** — inserir check de known URL **após** check de data e **antes** do fetch:
+```python
+# Known URL fence: pular artigos já conhecidos
+if url in self.known_urls:
+    self._consecutive_known += 1
+    logging.info(f"Skipping known article ({self._consecutive_known}/{self.KNOWN_URL_STOP_THRESHOLD}): {url}")
+    if self._consecutive_known >= self.KNOWN_URL_STOP_THRESHOLD:
+        logging.info(f"Known URL fence: {self.KNOWN_URL_STOP_THRESHOLD} consecutive known articles. Stopping.")
+        return False
+    return True  # Skip mas continua
+
+# Reset contador se encontrar artigo novo
+self._consecutive_known = 0
+
+# Fetch da página do artigo (só para artigos novos)
+content, image_url, published_dt, ... = self.get_article_content(url)
+```
+
+### Fase 3 — Refine (REFACTOR)
+
+- Verificar que todos os testes passam (antigos + novos)
+- `astro dev parse` — 157 DAGs, 0 erros
+
+## Backward compatibility
+
+- Se `known_urls` não for passado (ou for `set()`), o comportamento é idêntico ao atual
+- A comparação por data continua funcionando como fallback
+- Se a query ao DB falhar, `known_urls = set()` e o scraper opera normalmente
+
+## Verificação
+
+1. `poetry run pytest tests/` — todos os testes passam (antigos + novos)
+2. `astro dev parse` — 157 DAGs, 0 erros
+3. Teste manual: rodar scraper para uma agência e verificar nos logs:
+   - `"Skipping known article (1/3)"` aparece para artigos já processados
+   - `"Known URL fence: 3 consecutive known articles. Stopping."` aparece quando para cedo
+4. Comparar quantidade de fetches antes e depois (esperar redução significativa em execuções recorrentes)
+5. Na primeira execução (DB vazio ou agência nova), comportamento idêntico ao atual

--- a/src/govbr_scraper/scrapers/scrape_manager.py
+++ b/src/govbr_scraper/scrapers/scrape_manager.py
@@ -79,10 +79,16 @@ class ScrapeManager:
                 agency_urls = load_urls_from_yaml(config_dir, "site_urls.yaml")
 
             # Create list of (agency_name, scraper) tuples
-            webscrapers = [
-                (agency_name, WebScraper(min_date, url, max_date=max_date))
-                for agency_name, url in agency_urls.items()
-            ]
+            # Query known URLs for each agency to enable early stop optimization
+            webscrapers = []
+            for agency_name, url in agency_urls.items():
+                try:
+                    known_urls = self.storage.get_recent_urls(agency_name)
+                except Exception:
+                    known_urls = set()  # Fallback: no optimization
+                webscrapers.append(
+                    (agency_name, WebScraper(min_date, url, max_date=max_date, known_urls=known_urls))
+                )
 
             if sequential:
                 for agency_name, scraper in webscrapers:

--- a/src/govbr_scraper/scrapers/webscraper.py
+++ b/src/govbr_scraper/scrapers/webscraper.py
@@ -46,13 +46,16 @@ DEFAULT_HEADERS = {
 
 
 class WebScraper:
-    def __init__(self, min_date: str, base_url: str, max_date: Optional[str] = None):
+    KNOWN_URL_STOP_THRESHOLD = 3
+
+    def __init__(self, min_date: str, base_url: str, max_date: Optional[str] = None, known_urls: Optional[set] = None):
         """
         Initialize the scraper with minimum and maximum dates, and base URL.
 
         :param min_date: The minimum date for scraping news (format: YYYY-MM-DD).
         :param base_url: The base URL of the agency's news page.
         :param max_date: The maximum date for scraping news (format: YYYY-MM-DD).
+        :param known_urls: Set of article URLs already in the database (for skip/stop optimization).
         """
         self.base_url = base_url
         self.min_date = datetime.strptime(min_date, "%Y-%m-%d").date()
@@ -62,6 +65,8 @@ class WebScraper:
             self.max_date = None
         self.news_data = []
         self.agency = self.get_agency_name()
+        self.known_urls = known_urls or set()
+        self._consecutive_known = 0
 
     def get_agency_name(self) -> str:
         """
@@ -241,6 +246,22 @@ class WebScraper:
                     f"Skipping news dated {news_date} as it is newer than max_date {self.max_date}."
                 )
                 return True  # Skip this item
+
+        # Known URL fence: skip articles already in the database
+        if url in self.known_urls:
+            self._consecutive_known += 1
+            logging.info(
+                f"Skipping known article ({self._consecutive_known}/{self.KNOWN_URL_STOP_THRESHOLD}): {url}"
+            )
+            if self._consecutive_known >= self.KNOWN_URL_STOP_THRESHOLD:
+                logging.info(
+                    f"Known URL fence: {self.KNOWN_URL_STOP_THRESHOLD} consecutive known articles. Stopping."
+                )
+                return False
+            return True  # Skip but continue
+
+        # Reset consecutive counter on new article
+        self._consecutive_known = 0
 
         # Extract tags from listing (rarely works, but try anyway)
         tags_from_listing = self.extract_tags(item)

--- a/src/govbr_scraper/storage/postgres_manager.py
+++ b/src/govbr_scraper/storage/postgres_manager.py
@@ -135,6 +135,22 @@ class PostgresManager:
         logger.info("Closing all database connections")
         self.pool.closeall()
 
+    def get_recent_urls(self, agency_key: str, limit: int = 200) -> set[str]:
+        """Return URLs of recent articles for an agency (used for known URL fence optimization)."""
+        query = """
+            SELECT url FROM news
+            WHERE agency_key = %s AND url IS NOT NULL
+            ORDER BY published_at DESC
+            LIMIT %s
+        """
+        conn = self.pool.getconn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute(query, (agency_key, limit))
+                return {row[0] for row in cur.fetchall()}
+        finally:
+            self.pool.putconn(conn)
+
     def load_cache(self) -> None:
         """Load agencies and themes into memory cache."""
         if self._cache_loaded:

--- a/src/govbr_scraper/storage/storage_adapter.py
+++ b/src/govbr_scraper/storage/storage_adapter.py
@@ -45,6 +45,10 @@ class StorageAdapter:
             self._postgres_manager.load_cache()
         return self._postgres_manager
 
+    def get_recent_urls(self, agency_key: str, limit: int = 200) -> set[str]:
+        """Return recent article URLs for an agency (for known URL fence optimization)."""
+        return self.postgres.get_recent_urls(agency_key, limit)
+
     def insert(self, new_data: OrderedDict, allow_update: bool = False) -> int:
         """
         Insert new records into PostgreSQL.

--- a/tests/unit/test_known_url_fence.py
+++ b/tests/unit/test_known_url_fence.py
@@ -1,0 +1,247 @@
+"""Tests for the 'known URL fence' optimization in WebScraper.
+
+When known_urls is provided, the scraper should:
+- Skip fetching article pages for URLs already in the database
+- Stop pagination after N consecutive known URLs (fence)
+- Continue normally for unknown URLs
+- Maintain backward compatibility when known_urls is empty
+"""
+
+from datetime import date, datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from govbr_scraper.scrapers.webscraper import WebScraper
+
+
+@pytest.fixture
+def scraper():
+    """Create a WebScraper with known_urls for testing."""
+    known = {
+        "https://gov.br/mec/noticia-antiga-1",
+        "https://gov.br/mec/noticia-antiga-2",
+        "https://gov.br/mec/noticia-antiga-3",
+        "https://gov.br/mec/noticia-antiga-4",
+    }
+    s = WebScraper(
+        min_date="2026-03-01",
+        base_url="https://www.gov.br/mec/pt-br/assuntos/noticias",
+        max_date="2026-03-03",
+        known_urls=known,
+    )
+    return s
+
+
+@pytest.fixture
+def scraper_no_known():
+    """Create a WebScraper without known_urls (backward compat)."""
+    return WebScraper(
+        min_date="2026-03-01",
+        base_url="https://www.gov.br/mec/pt-br/assuntos/noticias",
+        max_date="2026-03-03",
+    )
+
+
+def _make_item_mock(scraper, url, title="Some Title", news_date=None):
+    """Helper: mock the extraction methods on scraper for a single item call."""
+    if news_date is None:
+        news_date = date(2026, 3, 2)
+    item = MagicMock()
+    scraper.extract_title_and_url = MagicMock(return_value=(title, url))
+    scraper.extract_category = MagicMock(return_value="Educação")
+    scraper.extract_date = MagicMock(return_value=news_date)
+    scraper.extract_tags = MagicMock(return_value=[])
+    brasilia_tz = timezone(timedelta(hours=-3))
+    scraper.get_article_content = MagicMock(
+        return_value=(
+            "Article content",
+            "https://img.gov.br/photo.jpg",
+            datetime(2026, 3, 2, 14, 30, tzinfo=brasilia_tz),
+            None,
+            ["tag1"],
+            None,
+            None,
+            "Educação",
+        )
+    )
+    return item
+
+
+class TestKnownUrlSkip:
+    """Known URLs should be skipped without fetching the article page."""
+
+    def test_known_article_is_skipped(self, scraper):
+        """Article with known URL should be skipped (no fetch)."""
+        item = _make_item_mock(scraper, "https://gov.br/mec/noticia-antiga-1")
+
+        result = scraper.extract_news_info(item)
+
+        assert result is True  # Continue processing
+        scraper.get_article_content.assert_not_called()
+        assert len(scraper.news_data) == 0  # Not added to results
+
+    def test_new_article_is_processed(self, scraper):
+        """Article with unknown URL should be fetched and processed normally."""
+        item = _make_item_mock(scraper, "https://gov.br/mec/noticia-nova")
+
+        result = scraper.extract_news_info(item)
+
+        assert result is True
+        scraper.get_article_content.assert_called_once_with("https://gov.br/mec/noticia-nova")
+        assert len(scraper.news_data) == 1
+        assert scraper.news_data[0]["url"] == "https://gov.br/mec/noticia-nova"
+
+
+class TestKnownUrlFenceStop:
+    """Consecutive known URLs should trigger a stop after threshold."""
+
+    def test_consecutive_known_urls_stop(self, scraper):
+        """3 consecutive known URLs should trigger stop (return False)."""
+        results = []
+        for i in range(1, 4):
+            item = _make_item_mock(scraper, f"https://gov.br/mec/noticia-antiga-{i}")
+            results.append(scraper.extract_news_info(item))
+
+        assert results == [True, True, False]  # skip, skip, STOP
+        assert scraper.get_article_content.call_count == 0  # No fetches at all
+        assert len(scraper.news_data) == 0
+
+    def test_new_article_resets_consecutive_counter(self, scraper):
+        """A new article between known ones should reset the consecutive counter."""
+        # Known 1
+        item1 = _make_item_mock(scraper, "https://gov.br/mec/noticia-antiga-1")
+        r1 = scraper.extract_news_info(item1)
+
+        # New article — resets counter
+        item2 = _make_item_mock(scraper, "https://gov.br/mec/noticia-nova")
+        r2 = scraper.extract_news_info(item2)
+
+        # Known 2 — counter restarts at 1
+        item3 = _make_item_mock(scraper, "https://gov.br/mec/noticia-antiga-2")
+        r3 = scraper.extract_news_info(item3)
+
+        # Known 3 — counter at 2, still below threshold
+        item4 = _make_item_mock(scraper, "https://gov.br/mec/noticia-antiga-3")
+        r4 = scraper.extract_news_info(item4)
+
+        assert [r1, r2, r3, r4] == [True, True, True, True]  # No stop
+        assert scraper._consecutive_known == 2  # 2 consecutive, not 3
+
+    def test_known_url_below_threshold_continues(self, scraper):
+        """1-2 consecutive known URLs should not trigger stop."""
+        item1 = _make_item_mock(scraper, "https://gov.br/mec/noticia-antiga-1")
+        r1 = scraper.extract_news_info(item1)
+
+        item2 = _make_item_mock(scraper, "https://gov.br/mec/noticia-antiga-2")
+        r2 = scraper.extract_news_info(item2)
+
+        assert r1 is True
+        assert r2 is True
+        assert scraper._consecutive_known == 2
+
+
+class TestBackwardCompatibility:
+    """Without known_urls, behavior should be identical to current."""
+
+    def test_empty_known_urls_processes_all(self, scraper_no_known):
+        """Without known_urls, all articles are fetched normally."""
+        s = scraper_no_known
+        item = _make_item_mock(s, "https://gov.br/mec/qualquer-noticia")
+
+        result = s.extract_news_info(item)
+
+        assert result is True
+        s.get_article_content.assert_called_once()
+        assert len(s.news_data) == 1
+
+    def test_date_stop_still_works_with_known_urls(self, scraper):
+        """Date-based stop condition should still work alongside known URL fence."""
+        old_date = date(2026, 2, 28)  # Before min_date (2026-03-01)
+        item = _make_item_mock(
+            scraper, "https://gov.br/mec/noticia-muito-velha", news_date=old_date
+        )
+
+        result = scraper.extract_news_info(item)
+
+        assert result is False  # Stop due to date
+        scraper.get_article_content.assert_not_called()
+
+
+class TestStorageGetRecentUrls:
+    """Tests for PostgresManager.get_recent_urls and StorageAdapter.get_recent_urls."""
+
+    def test_get_recent_urls_returns_set(self):
+        """get_recent_urls should return a set of URL strings."""
+        from govbr_scraper.storage.postgres_manager import PostgresManager
+
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.return_value = [
+            ("https://gov.br/mec/noticia-1",),
+            ("https://gov.br/mec/noticia-2",),
+        ]
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        pm = PostgresManager.__new__(PostgresManager)
+        pm.pool = MagicMock()
+        pm.pool.getconn.return_value = mock_conn
+
+        result = pm.get_recent_urls("mec")
+
+        assert result == {"https://gov.br/mec/noticia-1", "https://gov.br/mec/noticia-2"}
+        assert isinstance(result, set)
+        pm.pool.putconn.assert_called_once_with(mock_conn)
+
+    def test_get_recent_urls_respects_limit(self):
+        """get_recent_urls should pass limit to the SQL query."""
+        from govbr_scraper.storage.postgres_manager import PostgresManager
+
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.return_value = []
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        pm = PostgresManager.__new__(PostgresManager)
+        pm.pool = MagicMock()
+        pm.pool.getconn.return_value = mock_conn
+
+        pm.get_recent_urls("mec", limit=50)
+
+        mock_cursor.execute.assert_called_once()
+        args = mock_cursor.execute.call_args
+        assert args[0][1] == ("mec", 50)  # agency_key and limit params
+
+    def test_get_recent_urls_empty_for_unknown_agency(self):
+        """Unknown agency should return empty set (no error)."""
+        from govbr_scraper.storage.postgres_manager import PostgresManager
+
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.return_value = []
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        pm = PostgresManager.__new__(PostgresManager)
+        pm.pool = MagicMock()
+        pm.pool.getconn.return_value = mock_conn
+
+        result = pm.get_recent_urls("agencia_inexistente")
+
+        assert result == set()
+
+    def test_storage_adapter_delegates_to_postgres(self):
+        """StorageAdapter.get_recent_urls should delegate to PostgresManager."""
+        from govbr_scraper.storage.storage_adapter import StorageAdapter
+
+        mock_pm = MagicMock()
+        mock_pm.get_recent_urls.return_value = {"https://example.com/1"}
+
+        adapter = StorageAdapter(postgres_manager=mock_pm)
+
+        result = adapter.get_recent_urls("mec", limit=100)
+
+        assert result == {"https://example.com/1"}
+        mock_pm.get_recent_urls.assert_called_once_with("mec", 100)


### PR DESCRIPTION
## Summary

- Consulta URLs recentes no PostgreSQL antes de iniciar scraping de cada agência
- Artigos com URL já conhecida são pulados sem fetch da página (economia de HTTP requests)
- 3 artigos consecutivos conhecidos acionam parada antecipada ("fence") — não precisa processar o resto da listagem
- Backward-compatible: sem `known_urls`, comportamento é idêntico ao atual
- Inclui 11 testes unitários (TDD: testes escritos primeiro)

## Arquivos modificados

| Arquivo | Mudança |
|---------|---------|
| `webscraper.py` | Aceita `known_urls`, lógica de skip + fence em `extract_news_info` |
| `scrape_manager.py` | Consulta `get_recent_urls()` antes de criar WebScraper |
| `postgres_manager.py` | Novo método `get_recent_urls(agency_key, limit)` |
| `storage_adapter.py` | Expõe `get_recent_urls()` |
| `test_known_url_fence.py` | 11 testes cobrindo skip, fence, backward compat, storage |

## Test plan

- [x] 11 testes unitários novos passando
- [x] Suite completa: 98 testes, 0 falhas
- [ ] Deploy da API e verificar nos logs: `"Skipping known article"` e `"Known URL fence: stopping"`
- [ ] Comparar quantidade de fetches antes/depois em execuções recorrentes

🤖 Generated with [Claude Code](https://claude.com/claude-code)