### PR TITLE
feat: endpoint /verify/integrity para verificação de integridade

### DIFF
--- a/dags/config/site_urls.yaml
+++ b/dags/config/site_urls.yaml
@@ -146,7 +146,7 @@ agencies:
     url: https://www.gov.br/cti/pt-br/assuntos/noticias
     active: true
   ctir:
-    url: https://www.gov.br/ctir/pt-br/assuntos/noticias/2025
+    url: https://www.gov.br/ctir/pt-br/assuntos/noticias
     active: true
   cultura:
     url: https://www.gov.br/cultura/pt-br/assuntos/noticias
@@ -218,7 +218,7 @@ agencies:
     url: https://www.gov.br/gsi/pt-br/centrais-de-conteudo/noticias/2025
     active: true
   hfa:
-    url: https://www.gov.br/hfa/pt-br/noticias?b_start:int=0
+    url: https://www.gov.br/hfa/pt-br/noticias
     active: true
   ibama:
     url: https://www.gov.br/ibama/pt-br/assuntos/noticias/2025
@@ -247,7 +247,9 @@ agencies:
     active: true
   imprensanacional:
     url: https://www.gov.br/imprensanacional/pt-br/assuntos/noticias
-    active: true
+    active: false
+    disabled_date: "2026-03-04"
+    disabled_reason: "URL retorna 404. Site não tem página de notícias padrão."
   inca:
     url: https://www.gov.br/inca/pt-br/assuntos/noticias
     active: true
@@ -459,7 +461,7 @@ agencies:
     active: false
     disabled_date: "2025-01-15"
   sri:
-    url: https://www.gov.br/sri/pt-br/noticias/mais-noticias/ultimas-noticias
+    url: https://www.gov.br/sri/pt-br/noticias
     active: true
   sudam:
     url: https://www.gov.br/sudam/pt-br/noticias-1

--- a/src/govbr_scraper/api.py
+++ b/src/govbr_scraper/api.py
@@ -108,6 +108,34 @@ def scrape_agencies(req: ScrapeAgenciesRequest):
     return JSONResponse(content=response.model_dump(), status_code=http_status)
 
 
+class VerifyArticle(BaseModel):
+    unique_id: str
+    url: str | None = None
+    image_url: str | None = None
+    content_hash: str | None = None
+    source_etag: str | None = None
+    check_content: bool = False
+
+
+class VerifyRequest(BaseModel):
+    articles: list[VerifyArticle]
+
+
+@app.post("/verify/integrity")
+def verify_integrity(req: VerifyRequest):
+    from govbr_scraper.integrity.service import verify_batch
+
+    logger.info(f"Verificando integridade de {len(req.articles)} artigos")
+
+    try:
+        result = verify_batch([a.model_dump() for a in req.articles])
+    except Exception as e:
+        logger.error(f"Verificação de integridade falhou: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+    return result
+
+
 @app.post("/scrape/ebc", response_model=ScrapeResponse)
 def scrape_ebc(req: ScrapeEBCRequest):
     from govbr_scraper.storage import StorageAdapter

--- a/src/govbr_scraper/integrity/__init__.py
+++ b/src/govbr_scraper/integrity/__init__.py
@@ -1,0 +1,1 @@
+"""Verificação de integridade de notícias (imagens e conteúdo)."""

--- a/src/govbr_scraper/integrity/checker.py
+++ b/src/govbr_scraper/integrity/checker.py
@@ -1,0 +1,189 @@
+"""Funções puras de verificação de integridade de notícias."""
+
+import hashlib
+import logging
+from datetime import datetime, timezone
+
+import requests
+from bs4 import BeautifulSoup
+
+from govbr_scraper.scrapers.webscraper import DEFAULT_HEADERS
+
+logger = logging.getLogger(__name__)
+
+IMAGE_CHECK_TIMEOUT = 10
+CONTENT_CHECK_TIMEOUT = 15
+
+
+def check_image(image_url: str, timeout: int = IMAGE_CHECK_TIMEOUT) -> dict:
+    """HTTP HEAD na URL da imagem para verificar disponibilidade.
+
+    Args:
+        image_url: URL da imagem a verificar.
+        timeout: Timeout em segundos.
+
+    Returns:
+        Dict com image_status, image_http_code, image_checked_at, image_content_type.
+    """
+    now = datetime.now(timezone.utc).isoformat()
+
+    if not image_url:
+        return {
+            "image_status": "no_image",
+            "image_http_code": None,
+            "image_checked_at": now,
+            "image_content_type": None,
+        }
+
+    try:
+        resp = requests.head(
+            image_url,
+            headers=DEFAULT_HEADERS,
+            timeout=timeout,
+            allow_redirects=True,
+        )
+        content_type = resp.headers.get("content-type", "")
+        is_image = content_type.startswith("image/") or resp.status_code == 200
+
+        if resp.status_code == 200 and is_image:
+            status = "ok"
+        elif 300 <= resp.status_code < 400:
+            status = "redirect"
+        else:
+            status = "broken"
+
+        return {
+            "image_status": status,
+            "image_http_code": resp.status_code,
+            "image_checked_at": now,
+            "image_content_type": content_type,
+        }
+    except requests.exceptions.Timeout:
+        return {
+            "image_status": "timeout",
+            "image_http_code": None,
+            "image_checked_at": now,
+            "image_content_type": None,
+        }
+    except requests.exceptions.RequestException as e:
+        logger.warning(f"Erro ao verificar imagem {image_url}: {e}")
+        return {
+            "image_status": "broken",
+            "image_http_code": None,
+            "image_checked_at": now,
+            "image_content_type": None,
+        }
+
+
+def check_content(
+    source_url: str,
+    stored_hash: str | None = None,
+    stored_etag: str | None = None,
+    timeout: int = CONTENT_CHECK_TIMEOUT,
+) -> dict:
+    """GET condicional na URL fonte para detectar mudanças de conteúdo.
+
+    Usa If-None-Match (ETag) quando disponível para evitar download completo.
+    Compara hash SHA-256 do HTML do corpo da notícia.
+
+    Args:
+        source_url: URL original da notícia.
+        stored_hash: Hash SHA-256 armazenado da última verificação.
+        stored_etag: ETag armazenado da última verificação.
+        timeout: Timeout em segundos.
+
+    Returns:
+        Dict com content_status, content_hash, content_checked_at, source_etag, new_image_url.
+    """
+    now = datetime.now(timezone.utc).isoformat()
+
+    if not source_url:
+        return {
+            "content_status": "error",
+            "content_hash": stored_hash,
+            "content_checked_at": now,
+            "source_etag": stored_etag,
+            "new_image_url": None,
+        }
+
+    headers = dict(DEFAULT_HEADERS)
+    if stored_etag:
+        headers["If-None-Match"] = stored_etag
+
+    try:
+        resp = requests.get(source_url, headers=headers, timeout=timeout)
+
+        if resp.status_code == 304:
+            return {
+                "content_status": "unchanged",
+                "content_hash": stored_hash,
+                "content_checked_at": now,
+                "source_etag": stored_etag,
+                "new_image_url": None,
+            }
+
+        if resp.status_code == 404:
+            return {
+                "content_status": "removed",
+                "content_hash": stored_hash,
+                "content_checked_at": now,
+                "source_etag": None,
+                "new_image_url": None,
+            }
+
+        if resp.status_code != 200:
+            return {
+                "content_status": "error",
+                "content_hash": stored_hash,
+                "content_checked_at": now,
+                "source_etag": stored_etag,
+                "new_image_url": None,
+            }
+
+        # Extrair corpo do artigo e calcular hash
+        soup = BeautifulSoup(resp.content, "html.parser")
+        article_body = soup.find("div", {"id": "content-core"}) or soup.find(
+            "div", class_="content"
+        )
+
+        body_html = str(article_body) if article_body else resp.text
+        new_hash = "sha256:" + hashlib.sha256(body_html.encode("utf-8")).hexdigest()
+
+        # Extrair imagem atual da página
+        new_image_url = None
+        if article_body:
+            first_img = article_body.find("img")
+            if first_img and first_img.get("src"):
+                new_image_url = first_img["src"]
+
+        new_etag = resp.headers.get("etag")
+
+        if stored_hash and new_hash != stored_hash:
+            content_status = "changed"
+        else:
+            content_status = "unchanged"
+
+        return {
+            "content_status": content_status,
+            "content_hash": new_hash,
+            "content_checked_at": now,
+            "source_etag": new_etag,
+            "new_image_url": new_image_url,
+        }
+    except requests.exceptions.Timeout:
+        return {
+            "content_status": "error",
+            "content_hash": stored_hash,
+            "content_checked_at": now,
+            "source_etag": stored_etag,
+            "new_image_url": None,
+        }
+    except requests.exceptions.RequestException as e:
+        logger.warning(f"Erro ao verificar conteúdo {source_url}: {e}")
+        return {
+            "content_status": "error",
+            "content_hash": stored_hash,
+            "content_checked_at": now,
+            "source_etag": stored_etag,
+            "new_image_url": None,
+        }

--- a/src/govbr_scraper/integrity/service.py
+++ b/src/govbr_scraper/integrity/service.py
@@ -1,0 +1,126 @@
+"""Orquestrador de verificação de integridade em batch."""
+
+import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from govbr_scraper.integrity.checker import check_content, check_image
+
+logger = logging.getLogger(__name__)
+
+MAX_WORKERS = 20
+
+
+def _verify_article(article: dict) -> dict:
+    """Verifica integridade de um único artigo.
+
+    Args:
+        article: Dict com unique_id, url, image_url, content_hash, source_etag, check_content.
+
+    Returns:
+        Dict com unique_id e resultados de imagem e conteúdo.
+    """
+    unique_id = article["unique_id"]
+    result = {"unique_id": unique_id}
+
+    # Verificar imagem
+    image_result = check_image(article.get("image_url"))
+    result.update(image_result)
+
+    # Verificar conteúdo (apenas se solicitado)
+    if article.get("check_content"):
+        content_result = check_content(
+            source_url=article.get("url"),
+            stored_hash=article.get("content_hash"),
+            stored_etag=article.get("source_etag"),
+        )
+        result.update(content_result)
+    else:
+        result["content_status"] = "unchecked"
+
+    return result
+
+
+def verify_batch(articles: list[dict]) -> dict:
+    """Verifica integridade de um batch de artigos em paralelo.
+
+    Args:
+        articles: Lista de dicts com unique_id, url, image_url, content_hash,
+                  source_etag, check_content.
+
+    Returns:
+        Dict com results (lista) e summary (contadores).
+    """
+    if not articles:
+        return {"results": [], "summary": _empty_summary()}
+
+    results = []
+    workers = min(MAX_WORKERS, len(articles))
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = {
+            executor.submit(_verify_article, article): article["unique_id"]
+            for article in articles
+        }
+
+        for future in as_completed(futures):
+            uid = futures[future]
+            try:
+                result = future.result()
+                results.append(result)
+            except Exception as e:
+                logger.error(f"Erro verificando {uid}: {e}")
+                results.append({"unique_id": uid, "image_status": "error", "content_status": "error"})
+
+    summary = _compute_summary(results)
+    logger.info(
+        f"Verificação concluída: {summary['total']} artigos, "
+        f"{summary['images_broken']} imagens quebradas, "
+        f"{summary['content_changed']} conteúdos alterados"
+    )
+
+    return {"results": results, "summary": summary}
+
+
+def _empty_summary() -> dict:
+    return {
+        "total": 0,
+        "images_ok": 0,
+        "images_broken": 0,
+        "images_timeout": 0,
+        "images_no_image": 0,
+        "content_unchanged": 0,
+        "content_changed": 0,
+        "content_removed": 0,
+        "content_error": 0,
+        "content_unchecked": 0,
+    }
+
+
+def _compute_summary(results: list[dict]) -> dict:
+    summary = _empty_summary()
+    summary["total"] = len(results)
+
+    for r in results:
+        img = r.get("image_status", "error")
+        if img == "ok":
+            summary["images_ok"] += 1
+        elif img == "broken":
+            summary["images_broken"] += 1
+        elif img == "timeout":
+            summary["images_timeout"] += 1
+        elif img == "no_image":
+            summary["images_no_image"] += 1
+
+        cnt = r.get("content_status", "unchecked")
+        if cnt == "unchanged":
+            summary["content_unchanged"] += 1
+        elif cnt == "changed":
+            summary["content_changed"] += 1
+        elif cnt == "removed":
+            summary["content_removed"] += 1
+        elif cnt == "error":
+            summary["content_error"] += 1
+        elif cnt == "unchecked":
+            summary["content_unchecked"] += 1
+
+    return summary

--- a/src/govbr_scraper/scrapers/config/site_urls.yaml
+++ b/src/govbr_scraper/scrapers/config/site_urls.yaml
@@ -146,7 +146,7 @@ agencies:
     url: https://www.gov.br/cti/pt-br/assuntos/noticias
     active: true
   ctir:
-    url: https://www.gov.br/ctir/pt-br/assuntos/noticias/2025
+    url: https://www.gov.br/ctir/pt-br/assuntos/noticias
     active: true
   cultura:
     url: https://www.gov.br/cultura/pt-br/assuntos/noticias
@@ -218,7 +218,7 @@ agencies:
     url: https://www.gov.br/gsi/pt-br/centrais-de-conteudo/noticias/2025
     active: true
   hfa:
-    url: https://www.gov.br/hfa/pt-br/noticias?b_start:int=0
+    url: https://www.gov.br/hfa/pt-br/noticias
     active: true
   ibama:
     url: https://www.gov.br/ibama/pt-br/assuntos/noticias/2025
@@ -247,7 +247,9 @@ agencies:
     active: true
   imprensanacional:
     url: https://www.gov.br/imprensanacional/pt-br/assuntos/noticias
-    active: true
+    active: false
+    disabled_date: "2026-03-04"
+    disabled_reason: "URL retorna 404. Site não tem página de notícias padrão."
   inca:
     url: https://www.gov.br/inca/pt-br/assuntos/noticias
     active: true
@@ -459,7 +461,7 @@ agencies:
     active: false
     disabled_date: "2025-01-15"
   sri:
-    url: https://www.gov.br/sri/pt-br/noticias/mais-noticias/ultimas-noticias
+    url: https://www.gov.br/sri/pt-br/noticias
     active: true
   sudam:
     url: https://www.gov.br/sudam/pt-br/noticias-1

--- a/tests/unit/test_integrity.py
+++ b/tests/unit/test_integrity.py
@@ -1,0 +1,212 @@
+"""Testes unitários para verificação de integridade de notícias."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from govbr_scraper.integrity.checker import check_content, check_image
+from govbr_scraper.integrity.service import verify_batch
+
+
+# --- check_image ---
+
+
+class TestCheckImage:
+    def test_no_image_url(self):
+        result = check_image(None)
+        assert result["image_status"] == "no_image"
+        assert result["image_http_code"] is None
+
+    def test_empty_image_url(self):
+        result = check_image("")
+        assert result["image_status"] == "no_image"
+
+    @patch("govbr_scraper.integrity.checker.requests.head")
+    def test_image_ok(self, mock_head):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.headers = {"content-type": "image/jpeg"}
+        mock_head.return_value = mock_resp
+
+        result = check_image("https://www.gov.br/img.jpg")
+        assert result["image_status"] == "ok"
+        assert result["image_http_code"] == 200
+        assert result["image_content_type"] == "image/jpeg"
+        assert result["image_checked_at"] is not None
+
+    @patch("govbr_scraper.integrity.checker.requests.head")
+    def test_image_404(self, mock_head):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 404
+        mock_resp.headers = {"content-type": "text/html"}
+        mock_head.return_value = mock_resp
+
+        result = check_image("https://www.gov.br/img.jpg")
+        assert result["image_status"] == "broken"
+        assert result["image_http_code"] == 404
+
+    @patch("govbr_scraper.integrity.checker.requests.head")
+    def test_image_timeout(self, mock_head):
+        mock_head.side_effect = requests.exceptions.Timeout()
+
+        result = check_image("https://www.gov.br/img.jpg")
+        assert result["image_status"] == "timeout"
+        assert result["image_http_code"] is None
+
+    @patch("govbr_scraper.integrity.checker.requests.head")
+    def test_image_connection_error(self, mock_head):
+        mock_head.side_effect = requests.exceptions.ConnectionError()
+
+        result = check_image("https://www.gov.br/img.jpg")
+        assert result["image_status"] == "broken"
+
+
+# --- check_content ---
+
+
+class TestCheckContent:
+    def test_no_source_url(self):
+        result = check_content(None)
+        assert result["content_status"] == "error"
+
+    @patch("govbr_scraper.integrity.checker.requests.get")
+    def test_content_304_not_modified(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 304
+        mock_get.return_value = mock_resp
+
+        result = check_content(
+            "https://www.gov.br/noticia",
+            stored_hash="sha256:abc",
+            stored_etag='"etag123"',
+        )
+        assert result["content_status"] == "unchanged"
+        assert result["content_hash"] == "sha256:abc"
+
+    @patch("govbr_scraper.integrity.checker.requests.get")
+    def test_content_404_removed(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 404
+        mock_get.return_value = mock_resp
+
+        result = check_content("https://www.gov.br/noticia")
+        assert result["content_status"] == "removed"
+
+    @patch("govbr_scraper.integrity.checker.requests.get")
+    def test_content_unchanged_same_hash(self, mock_get):
+        html = b'<div id="content-core"><p>Texto da noticia</p></div>'
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.content = html
+        mock_resp.text = html.decode()
+        mock_resp.headers = {}
+        mock_get.return_value = mock_resp
+
+        # Primeiro call para obter o hash
+        result1 = check_content("https://www.gov.br/noticia")
+        assert result1["content_status"] == "unchanged"  # sem stored_hash, sempre unchanged
+        stored_hash = result1["content_hash"]
+
+        # Segundo call com mesmo conteúdo
+        result2 = check_content("https://www.gov.br/noticia", stored_hash=stored_hash)
+        assert result2["content_status"] == "unchanged"
+
+    @patch("govbr_scraper.integrity.checker.requests.get")
+    def test_content_changed_different_hash(self, mock_get):
+        html = b'<div id="content-core"><p>Texto modificado</p></div>'
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.content = html
+        mock_resp.text = html.decode()
+        mock_resp.headers = {"etag": '"new_etag"'}
+        mock_get.return_value = mock_resp
+
+        result = check_content(
+            "https://www.gov.br/noticia",
+            stored_hash="sha256:hash_antigo",
+        )
+        assert result["content_status"] == "changed"
+        assert result["content_hash"].startswith("sha256:")
+        assert result["source_etag"] == '"new_etag"'
+
+    @patch("govbr_scraper.integrity.checker.requests.get")
+    def test_content_extracts_new_image_url(self, mock_get):
+        html = b'<div id="content-core"><img src="https://gov.br/nova.jpg"/><p>Texto</p></div>'
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.content = html
+        mock_resp.text = html.decode()
+        mock_resp.headers = {}
+        mock_get.return_value = mock_resp
+
+        result = check_content("https://www.gov.br/noticia", stored_hash="sha256:old")
+        assert result["new_image_url"] == "https://gov.br/nova.jpg"
+
+    @patch("govbr_scraper.integrity.checker.requests.get")
+    def test_content_timeout(self, mock_get):
+        mock_get.side_effect = requests.exceptions.Timeout()
+
+        result = check_content("https://www.gov.br/noticia")
+        assert result["content_status"] == "error"
+
+
+# --- verify_batch ---
+
+
+class TestVerifyBatch:
+    def test_empty_batch(self):
+        result = verify_batch([])
+        assert result["results"] == []
+        assert result["summary"]["total"] == 0
+
+    @patch("govbr_scraper.integrity.service.check_image")
+    def test_batch_image_only(self, mock_check_image):
+        mock_check_image.return_value = {
+            "image_status": "ok",
+            "image_http_code": 200,
+            "image_checked_at": "2026-01-01T00:00:00Z",
+            "image_content_type": "image/jpeg",
+        }
+
+        articles = [
+            {"unique_id": "abc123", "image_url": "https://gov.br/img.jpg"},
+            {"unique_id": "def456", "image_url": "https://gov.br/img2.jpg"},
+        ]
+        result = verify_batch(articles)
+
+        assert result["summary"]["total"] == 2
+        assert result["summary"]["images_ok"] == 2
+        assert result["summary"]["content_unchecked"] == 2
+        assert len(result["results"]) == 2
+
+    @patch("govbr_scraper.integrity.service.check_content")
+    @patch("govbr_scraper.integrity.service.check_image")
+    def test_batch_with_content_check(self, mock_check_image, mock_check_content):
+        mock_check_image.return_value = {
+            "image_status": "broken",
+            "image_http_code": 404,
+            "image_checked_at": "2026-01-01T00:00:00Z",
+            "image_content_type": None,
+        }
+        mock_check_content.return_value = {
+            "content_status": "changed",
+            "content_hash": "sha256:new",
+            "content_checked_at": "2026-01-01T00:00:00Z",
+            "source_etag": None,
+            "new_image_url": "https://gov.br/nova.jpg",
+        }
+
+        articles = [
+            {
+                "unique_id": "abc123",
+                "url": "https://gov.br/noticia",
+                "image_url": "https://gov.br/img.jpg",
+                "check_content": True,
+            },
+        ]
+        result = verify_batch(articles)
+
+        assert result["summary"]["total"] == 1
+        assert result["summary"]["images_broken"] == 1
+        assert result["summary"]["content_changed"] == 1


### PR DESCRIPTION
## Summary

- Novo módulo `integrity/` com funções de verificação de imagens (HTTP HEAD) e conteúdo (GET condicional com ETag + SHA-256)
- Endpoint `POST /verify/integrity` que recebe batch de artigos e retorna status por artigo
- Paralelismo via ThreadPoolExecutor (max 20 workers)

## Contexto

Quando notícias são editadas nos sites gov.br, imagens podem mudar ou ser removidas, quebrando o portal. Este endpoint é chamado pela DAG `verify_news_integrity` do data-platform para verificar periodicamente a integridade.

Ref: data-platform#68

## Test plan

- [x] 16 testes unitários passando (checker, service, batch)
- [ ] Testar localmente: `poetry run uvicorn govbr_scraper.api:app --reload` + curl
- [ ] Validar no Cloud Run após deploy