### PR TITLE
fix: Plone6APIScraper para agências com Volto (issue #30)

### DIFF
--- a/dags/config/site_urls.yaml
+++ b/dags/config/site_urls.yaml
@@ -141,9 +141,8 @@ agencies:
     active: true
   ctav:
     url: https://www.gov.br/ctav/pt-br/noticias
-    active: false
-    disabled_reason: "Volto/SPA - requer JavaScript"
-    disabled_date: "2026-03-18"
+    active: true
+    scraper_type: plone6_api
   cti:
     url: https://www.gov.br/cti/pt-br/assuntos/noticias
     active: true
@@ -179,17 +178,15 @@ agencies:
     active: true
   esg:
     url: https://www.gov.br/esg/pt-br/centrais-de-conteudo/noticias
-    active: false
-    disabled_reason: "Volto/SPA - requer JavaScript"
-    disabled_date: "2026-03-18"
+    active: true
+    scraper_type: plone6_api
   esocial:
     url: https://www.gov.br/esocial/pt-br/noticias
     active: true
   esporte:
     url: https://www.gov.br/esporte/pt-br/noticias-e-conteudos/esporte
-    active: false
-    disabled_reason: "Volto/SPA - requer JavaScript"
-    disabled_date: "2026-03-18"
+    active: true
+    scraper_type: plone6_api
   fazenda:
     url: https://www.gov.br/fazenda/pt-br/assuntos/noticias
     active: true
@@ -225,9 +222,8 @@ agencies:
     active: true
   hfa:
     url: https://www.gov.br/hfa/pt-br/noticias
-    active: false
-    disabled_reason: "Volto/SPA - requer JavaScript"
-    disabled_date: "2026-03-18"
+    active: true
+    scraper_type: plone6_api
   ibama:
     url: https://www.gov.br/ibama/pt-br/assuntos/noticias/2025
     active: true
@@ -355,9 +351,8 @@ agencies:
     active: true
   memp:
     url: https://www.gov.br/memp/pt-br/assuntos/noticias
-    active: false
-    disabled_reason: "Volto/SPA - requer JavaScript"
-    disabled_date: "2026-03-18"
+    active: true
+    scraper_type: plone6_api
   mj:
     url: https://www.gov.br/mj/pt-br/assuntos/noticias
     active: true
@@ -400,6 +395,7 @@ agencies:
   patrimonio:
     url: https://www.gov.br/patrimonio/pt-br/central-de-conteudo/noticias
     active: true
+    scraper_type: plone6_api
   pf:
     url: https://www.gov.br/pf/pt-br/assuntos/noticias/noticias-destaque
     active: true
@@ -415,14 +411,14 @@ agencies:
   pncp:
     url: https://www.gov.br/pncp/pt-br/central-de-conteudo/noticias
     active: true
+    scraper_type: plone6_api
   portos-e-aeroportos:
     url: https://www.gov.br/portos-e-aeroportos/pt-br/assuntos/noticias
     active: true
   povosindigenas:
     url: https://www.gov.br/povosindigenas/pt-br/assuntos/noticias
-    active: false
-    disabled_reason: "Volto/SPA - requer JavaScript"
-    disabled_date: "2025-01-15"
+    active: true
+    scraper_type: plone6_api
   previc:
     url: https://www.gov.br/previc/pt-br/noticias
     active: true
@@ -440,14 +436,14 @@ agencies:
   propriedade-intelectual:
     url: https://www.gov.br/propriedade-intelectual/pt-br/assuntos/noticias
     active: true
+    scraper_type: plone6_api
   receitafederal:
     url: https://www.gov.br/receitafederal/pt-br/assuntos/noticias
     active: true
   reconstrucaors:
     url: https://www.gov.br/reconstrucaors/pt-br/acompanhe-a-reconstrucao/noticias
-    active: false
-    disabled_reason: "Volto/SPA - requer JavaScript"
-    disabled_date: "2026-03-18"
+    active: true
+    scraper_type: plone6_api
   saude:
     url: https://www.gov.br/saude/pt-br/assuntos/noticias
     active: true
@@ -491,6 +487,7 @@ agencies:
   susep:
     url: https://www.gov.br/susep/pt-br/central-de-conteudos/noticias
     active: true
+    scraper_type: plone6_api
   tesouronacional:
     url: https://www.gov.br/tesouronacional/pt-br/noticias
     active: true

--- a/src/govbr_scraper/scrapers/config/site_urls.yaml
+++ b/src/govbr_scraper/scrapers/config/site_urls.yaml
@@ -141,9 +141,8 @@ agencies:
     active: true
   ctav:
     url: https://www.gov.br/ctav/pt-br/noticias
-    active: false
-    disabled_reason: "Volto/SPA - requer JavaScript"
-    disabled_date: "2026-03-18"
+    active: true
+    scraper_type: plone6_api
   cti:
     url: https://www.gov.br/cti/pt-br/assuntos/noticias
     active: true
@@ -179,17 +178,15 @@ agencies:
     active: true
   esg:
     url: https://www.gov.br/esg/pt-br/centrais-de-conteudo/noticias
-    active: false
-    disabled_reason: "Volto/SPA - requer JavaScript"
-    disabled_date: "2026-03-18"
+    active: true
+    scraper_type: plone6_api
   esocial:
     url: https://www.gov.br/esocial/pt-br/noticias
     active: true
   esporte:
     url: https://www.gov.br/esporte/pt-br/noticias-e-conteudos/esporte
-    active: false
-    disabled_reason: "Volto/SPA - requer JavaScript"
-    disabled_date: "2026-03-18"
+    active: true
+    scraper_type: plone6_api
   fazenda:
     url: https://www.gov.br/fazenda/pt-br/assuntos/noticias
     active: true
@@ -225,9 +222,8 @@ agencies:
     active: true
   hfa:
     url: https://www.gov.br/hfa/pt-br/noticias
-    active: false
-    disabled_reason: "Volto/SPA - requer JavaScript"
-    disabled_date: "2026-03-18"
+    active: true
+    scraper_type: plone6_api
   ibama:
     url: https://www.gov.br/ibama/pt-br/assuntos/noticias/2025
     active: true
@@ -355,9 +351,8 @@ agencies:
     active: true
   memp:
     url: https://www.gov.br/memp/pt-br/assuntos/noticias
-    active: false
-    disabled_reason: "Volto/SPA - requer JavaScript"
-    disabled_date: "2026-03-18"
+    active: true
+    scraper_type: plone6_api
   mj:
     url: https://www.gov.br/mj/pt-br/assuntos/noticias
     active: true
@@ -400,6 +395,7 @@ agencies:
   patrimonio:
     url: https://www.gov.br/patrimonio/pt-br/central-de-conteudo/noticias
     active: true
+    scraper_type: plone6_api
   pf:
     url: https://www.gov.br/pf/pt-br/assuntos/noticias/noticias-destaque
     active: true
@@ -415,14 +411,14 @@ agencies:
   pncp:
     url: https://www.gov.br/pncp/pt-br/central-de-conteudo/noticias
     active: true
+    scraper_type: plone6_api
   portos-e-aeroportos:
     url: https://www.gov.br/portos-e-aeroportos/pt-br/assuntos/noticias
     active: true
   povosindigenas:
     url: https://www.gov.br/povosindigenas/pt-br/assuntos/noticias
-    active: false
-    disabled_reason: "Volto/SPA - requer JavaScript"
-    disabled_date: "2025-01-15"
+    active: true
+    scraper_type: plone6_api
   previc:
     url: https://www.gov.br/previc/pt-br/noticias
     active: true
@@ -440,14 +436,14 @@ agencies:
   propriedade-intelectual:
     url: https://www.gov.br/propriedade-intelectual/pt-br/assuntos/noticias
     active: true
+    scraper_type: plone6_api
   receitafederal:
     url: https://www.gov.br/receitafederal/pt-br/assuntos/noticias
     active: true
   reconstrucaors:
     url: https://www.gov.br/reconstrucaors/pt-br/acompanhe-a-reconstrucao/noticias
-    active: false
-    disabled_reason: "Volto/SPA - requer JavaScript"
-    disabled_date: "2026-03-18"
+    active: true
+    scraper_type: plone6_api
   saude:
     url: https://www.gov.br/saude/pt-br/assuntos/noticias
     active: true
@@ -491,6 +487,7 @@ agencies:
   susep:
     url: https://www.gov.br/susep/pt-br/central-de-conteudos/noticias
     active: true
+    scraper_type: plone6_api
   tesouronacional:
     url: https://www.gov.br/tesouronacional/pt-br/noticias
     active: true

--- a/src/govbr_scraper/scrapers/ebc_scrape_manager.py
+++ b/src/govbr_scraper/scrapers/ebc_scrape_manager.py
@@ -82,8 +82,8 @@ class EBCScrapeManager:
 
             # Create list of (agency_name, scraper) tuples
             webscrapers = [
-                (agency_name, EBCWebScraper(min_date, url, max_date=max_date))
-                for agency_name, url in agency_urls.items()
+                (agency_name, EBCWebScraper(min_date, agency_config["url"], max_date=max_date))
+                for agency_name, agency_config in agency_urls.items()
             ]
 
             if sequential:

--- a/src/govbr_scraper/scrapers/plone6_api_scraper.py
+++ b/src/govbr_scraper/scrapers/plone6_api_scraper.py
@@ -358,9 +358,12 @@ class Plone6APIScraper:
             if isinstance(image_data, dict):
                 download_path = image_data.get("download")
                 if download_path:
-                    # Construir URL completa
-                    base_url = url.rsplit("/", 1)[0]
-                    image_url = f"{base_url}/{download_path}"
+                    # Se já for URL absoluta, usar diretamente; caso contrário,
+                    # concatenar com a URL do artigo (não com o pai)
+                    if download_path.startswith("http"):
+                        image_url = download_path
+                    else:
+                        image_url = f"{url}/{download_path}"
 
         # 7. Categoria e tags (Subject no Plone)
         subject = item.get("Subject", [])
@@ -387,5 +390,5 @@ class Plone6APIScraper:
             "content": content_md,
             "image": image_url,
             "agency": self.agency,
-            "extracted_at": datetime.now(),
+            "extracted_at": datetime.now(timezone.utc),
         }

--- a/src/govbr_scraper/scrapers/plone6_api_scraper.py
+++ b/src/govbr_scraper/scrapers/plone6_api_scraper.py
@@ -1,0 +1,391 @@
+"""
+Scraper para agências gov.br que usam Plone 6 com Volto (React SPA).
+
+Utiliza a REST API do Plone (++api++) em vez de parsing HTML, pois
+o conteúdo é renderizado client-side via JavaScript.
+"""
+import json
+import logging
+import random
+import re
+import time
+from datetime import datetime, timezone, timedelta
+from typing import Dict, List, Optional
+from urllib.parse import urlparse, urlunparse
+
+import requests
+from markdownify import markdownify as md
+from retry import retry
+
+# Importar constantes e exceções do WebScraper
+from govbr_scraper.scrapers.webscraper import (
+    ScrapingError,
+    DEFAULT_HEADERS,
+    SLEEP_TIME_INTERVAL,
+)
+
+# Configurar logging (mesmo padrão do WebScraper)
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+)
+
+
+class Plone6APIScraper:
+    """
+    Scraper para agências gov.br que usam Plone 6 com Volto (React SPA).
+
+    Utiliza a REST API do Plone (++api++) em vez de parsing HTML, pois
+    o conteúdo é renderizado client-side via JavaScript.
+    """
+
+    KNOWN_URL_STOP_THRESHOLD = 3
+
+    def __init__(
+        self,
+        min_date: str,
+        base_url: str,
+        max_date: Optional[str] = None,
+        known_urls: Optional[set] = None
+    ):
+        """
+        Inicializar scraper (interface compatível com WebScraper).
+
+        :param min_date: Data mínima (formato: YYYY-MM-DD)
+        :param base_url: URL base da página de notícias
+        :param max_date: Data máxima (formato: YYYY-MM-DD)
+        :param known_urls: Set de URLs já no banco (otimização)
+        """
+        self.base_url = base_url
+        self.min_date = datetime.strptime(min_date, "%Y-%m-%d").date()
+        self.max_date = (
+            datetime.strptime(max_date, "%Y-%m-%d").date()
+            if max_date else None
+        )
+        self.news_data = []
+        self.agency = self.get_agency_name()
+        self.known_urls = known_urls or set()
+        self._consecutive_known = 0
+
+    def get_agency_name(self) -> str:
+        """
+        Extrair nome da agência da URL base.
+
+        :return: Nome da agência
+        """
+        return self.base_url.split("/")[3]
+
+    def scrape_news(self) -> List[Dict[str, str]]:
+        """
+        Scraper notícias via API REST do Plone 6.
+
+        :return: Lista de dicionários com dados das notícias
+        :raises ScrapingError: Se houver falha na API ou rede
+        """
+        current_start = 0
+        page_size = 25  # Itens por página
+
+        while True:
+            api_url = self._build_api_url(current_start, page_size)
+
+            try:
+                response_data = self._fetch_api_page(api_url)
+            except ScrapingError:
+                raise  # Propagar erro detectável
+            except requests.exceptions.RequestException as e:
+                raise ScrapingError(
+                    f"Erro de rede ao acessar API de {self.agency}: {str(e)}"
+                ) from e
+
+            items = response_data.get("items", [])
+            items_total = response_data.get("items_total", 0)
+
+            if not items:
+                logging.info(f"Nenhuma notícia encontrada para {self.agency}.")
+                break
+
+            logging.info(
+                f"Processando {len(items)} notícias "
+                f"(offset {current_start}/{items_total})"
+            )
+
+            # Processar cada item
+            for item in items:
+                # Sleep entre requests (mesmo padrão do WebScraper)
+                time.sleep(random.uniform(*SLEEP_TIME_INTERVAL))
+
+                should_continue = self._process_news_item(item)
+                if not should_continue:
+                    # Parar se data < min_date ou known URL fence
+                    return self.news_data
+
+            # Próxima página
+            current_start += len(items)
+            if current_start >= items_total:
+                logging.info(f"Todas as notícias processadas para {self.agency}.")
+                break
+
+        return self.news_data
+
+    def _build_api_url(self, b_start: int, b_size: int) -> str:
+        """
+        Construir URL da API REST do Plone a partir da URL base.
+
+        Exemplo:
+        Input:  https://www.gov.br/susep/pt-br/central-de-conteudos/noticias
+        Output: https://www.gov.br/susep/++api++/pt-br/central-de-conteudos/noticias/@search?...
+
+        :param b_start: Offset de paginação
+        :param b_size: Itens por página
+        :return: URL da API completa
+        """
+        parsed = urlparse(self.base_url)
+
+        # Extrair partes: /AGENCY/PATH
+        path_parts = parsed.path.strip("/").split("/", 1)
+        agency = path_parts[0]  # Ex: "susep"
+        rest_of_path = path_parts[1] if len(path_parts) > 1 else ""
+
+        # Construir novo path: /AGENCY/++api++/PATH/@search
+        api_path = f"/{agency}/++api++/{rest_of_path}/@search"
+
+        # Query parameters
+        params = [
+            "portal_type=News Item",
+            "sort_on=effective",
+            "sort_order=descending",
+            f"b_start={b_start}",
+            f"b_size={b_size}",
+            "fullobjects=1",  # Retornar objetos completos (com conteúdo)
+            "metadata_fields=title",
+            "metadata_fields=effective",
+            "metadata_fields=modified",
+            "metadata_fields=description",
+        ]
+        query_string = "&".join(params)
+
+        # Reconstruir URL
+        api_url = urlunparse((
+            parsed.scheme,
+            parsed.netloc,
+            api_path,
+            "",  # params
+            query_string,
+            ""   # fragment
+        ))
+
+        return api_url
+
+    @retry(
+        exceptions=requests.exceptions.RequestException,
+        tries=5,
+        delay=2,
+        backoff=3,
+        jitter=(1, 3),
+    )
+    def _fetch_api_page(self, api_url: str) -> dict:
+        """
+        Fetch página da API com retry logic (mesmo padrão do WebScraper).
+
+        :param api_url: URL da API
+        :return: Dict com resposta JSON
+        :raises ScrapingError: Se resposta não for JSON válido
+        """
+        logging.info(f"Fetching API: {api_url}")
+
+        headers = DEFAULT_HEADERS.copy()
+        headers["Accept"] = "application/json"
+
+        response = requests.get(api_url, headers=headers, timeout=20)
+        response.raise_for_status()
+
+        try:
+            data = response.json()
+        except json.JSONDecodeError as e:
+            raise ScrapingError(
+                f"API de {self.agency} retornou resposta não-JSON. "
+                f"Possível problema de autenticação ou mudança de endpoint. "
+                f"URL: {api_url}"
+            ) from e
+
+        return data
+
+    def _process_news_item(self, item: dict) -> bool:
+        """
+        Processar um item da API e adicionar ao news_data.
+
+        Aplica filtros:
+        - Data < min_date: parar
+        - Data > max_date: pular
+        - URL conhecida: known URL fence (parar após 3 consecutivas)
+
+        :param item: Dict do JSON da API
+        :return: True para continuar, False para parar
+        """
+        # 1. Extrair dados básicos
+        url = item.get("@id", "")
+        title = item.get("title", "No Title")
+
+        # 2. Extrair e validar data
+        effective_str = item.get("effective")
+        if effective_str:
+            try:
+                published_dt = datetime.fromisoformat(effective_str)
+                news_date = published_dt.date()
+            except (ValueError, AttributeError):
+                logging.warning(f"Data inválida em {url}: {effective_str}")
+                news_date = None
+                published_dt = None
+        else:
+            news_date = None
+            published_dt = None
+
+        # 3. Filtro de data (mesma lógica do WebScraper.extract_news_info)
+        if news_date:
+            if news_date < self.min_date:
+                logging.info(
+                    f"Parando scrape. Notícia mais antiga que min_date: {news_date}"
+                )
+                return False  # PARAR
+            if self.max_date and news_date > self.max_date:
+                logging.info(
+                    f"Pulando notícia de {news_date} (mais nova que max_date)"
+                )
+                return True  # PULAR mas continuar
+
+        # 4. Known URL fence (mesma lógica do WebScraper)
+        if url in self.known_urls:
+            self._consecutive_known += 1
+            logging.info(
+                f"Pulando artigo conhecido "
+                f"({self._consecutive_known}/{self.KNOWN_URL_STOP_THRESHOLD}): {url}"
+            )
+            if self._consecutive_known >= self.KNOWN_URL_STOP_THRESHOLD:
+                logging.info(
+                    f"Known URL fence: {self.KNOWN_URL_STOP_THRESHOLD} "
+                    f"artigos consecutivos conhecidos. Parando."
+                )
+                return False  # PARAR
+            return True  # PULAR mas continuar
+
+        # 5. Reset contador (artigo novo encontrado)
+        self._consecutive_known = 0
+
+        # 6. Transformar e adicionar
+        news_item = self._transform_news_item(item, published_dt)
+
+        logging.info(f"Artigo extraído: {news_date} - {url}\n")
+
+        self.news_data.append(news_item)
+        return True  # CONTINUAR
+
+    def _transform_news_item(
+        self,
+        item: dict,
+        published_dt: Optional[datetime]
+    ) -> Dict[str, str]:
+        """
+        Transformar item da API do Plone para formato interno.
+
+        :param item: Dict do JSON da API
+        :param published_dt: Datetime já parseado
+        :return: Dict no formato esperado pelo ScrapeManager
+        """
+        # 1. URL
+        url = item.get("@id", "")
+
+        # 2. Título
+        title = item.get("title", "No Title")
+
+        # 3. Data de atualização
+        modified_str = item.get("modified")
+        if modified_str:
+            try:
+                updated_dt = datetime.fromisoformat(modified_str)
+            except (ValueError, AttributeError):
+                updated_dt = None
+        else:
+            updated_dt = None
+
+        # 4. Subtítulo (description)
+        subtitle = item.get("description", None)
+
+        # 5. Conteúdo: Extrair de blocks (Plone 6 usa formato blocks/slate)
+        content_md = ""
+
+        # Tentar extrair de blocks
+        blocks = item.get("blocks", {})
+        if blocks:
+            # Procurar por blocos do tipo 'slate' ou 'text'
+            for block_id, block_data in blocks.items():
+                if isinstance(block_data, dict):
+                    block_type = block_data.get("@type", "")
+
+                    # Slate block (formato Volto)
+                    if block_type == "slate":
+                        plaintext = block_data.get("plaintext", "")
+                        if plaintext:
+                            content_md += plaintext + "\n\n"
+
+                    # Text block (formato alternativo)
+                    elif block_type in ["text", "textBlock"]:
+                        text = block_data.get("text", "")
+                        if text:
+                            # Se for HTML, converter para Markdown
+                            if "<" in text and ">" in text:
+                                content_md += md(text) + "\n\n"
+                            else:
+                                content_md += text + "\n\n"
+
+        # Fallback: tentar campo 'text' (formato antigo)
+        if not content_md:
+            text_data = item.get("text", {})
+            if isinstance(text_data, dict):
+                content_html = text_data.get("data", "")
+            else:
+                content_html = str(text_data) if text_data else ""
+
+            if content_html:
+                content_md = md(content_html)
+
+        # Limpeza básica
+        if content_md:
+            content_md = re.sub(r'\n{3,}', '\n\n', content_md).strip()
+
+        # 6. Imagem
+        image_url = None
+        if "image" in item:
+            image_data = item["image"]
+            if isinstance(image_data, dict):
+                download_path = image_data.get("download")
+                if download_path:
+                    # Construir URL completa
+                    base_url = url.rsplit("/", 1)[0]
+                    image_url = f"{base_url}/{download_path}"
+
+        # 7. Categoria e tags (Subject no Plone)
+        subject = item.get("Subject", [])
+        if isinstance(subject, list):
+            category = subject[0] if subject else "No Category"
+            tags = subject  # Lista completa
+        else:
+            category = "No Category"
+            tags = []
+
+        # 8. Editorial lead (geralmente não disponível na API)
+        editorial_lead = None
+
+        # 9. Montar dict final
+        return {
+            "title": title,
+            "url": url,
+            "published_at": published_dt,
+            "updated_datetime": updated_dt,
+            "category": category,
+            "tags": tags,
+            "editorial_lead": editorial_lead,
+            "subtitle": subtitle,
+            "content": content_md,
+            "image": image_url,
+            "agency": self.agency,
+            "extracted_at": datetime.now(),
+        }

--- a/src/govbr_scraper/scrapers/scrape_manager.py
+++ b/src/govbr_scraper/scrapers/scrape_manager.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List
 from govbr_scraper.models.monitoring import classify_error
 from govbr_scraper.monitoring.structured_log import log_scrape_result
 from govbr_scraper.scrapers.unique_id import generate_readable_unique_id
+from govbr_scraper.scrapers.plone6_api_scraper import Plone6APIScraper
 from govbr_scraper.scrapers.webscraper import ScrapingError, WebScraper
 from govbr_scraper.scrapers.yaml_config import get_config_dir, load_urls_from_yaml
 
@@ -83,14 +84,20 @@ class ScrapeManager:
             # Create list of (agency_name, scraper) tuples
             # Query known URLs for each agency to enable early stop optimization
             webscrapers = []
-            for agency_name, url in agency_urls.items():
+            for agency_name, agency_config in agency_urls.items():
+                url = agency_config["url"]
+                scraper_type = agency_config.get("scraper_type", "html")
                 try:
                     known_urls = self.dataset_manager.get_recent_urls(agency_name)
                 except Exception:
                     known_urls = set()  # Fallback: no optimization
-                webscrapers.append(
-                    (agency_name, WebScraper(min_date, url, max_date=max_date, known_urls=known_urls))
-                )
+                # Strategy Pattern: select scraper based on config
+                if scraper_type == "plone6_api":
+                    scraper = Plone6APIScraper(min_date, url, max_date=max_date, known_urls=known_urls)
+                    logging.info(f"Using Plone6APIScraper for {agency_name}")
+                else:
+                    scraper = WebScraper(min_date, url, max_date=max_date, known_urls=known_urls)
+                webscrapers.append((agency_name, scraper))
 
             if sequential:
                 for agency_name, scraper in webscrapers:

--- a/src/govbr_scraper/scrapers/yaml_config.py
+++ b/src/govbr_scraper/scrapers/yaml_config.py
@@ -20,7 +20,7 @@ def get_config_dir(module_file: str) -> str:
 
 def load_urls_from_yaml(
     config_dir: str, file_name: str, agency: str = None
-) -> Dict[str, str]:
+) -> Dict[str, dict]:
     """
     Load URLs from a YAML file.
 
@@ -29,13 +29,14 @@ def load_urls_from_yaml(
           agency_key:
             url: str
             active: bool  # optional, defaults to True
+            scraper_type: str  # optional, defaults to 'html'
             disabled_reason: str  # optional
             disabled_date: str  # optional
 
     :param config_dir: Directory containing the YAML file.
     :param file_name: The name of the YAML file.
     :param agency: Specific agency key to filter URLs. If None, load all active URLs.
-    :return: A dict mapping agency_name to URL.
+    :return: A dict mapping agency_name to a config dict with 'url', 'scraper_type', 'active'.
     :raises ValueError: If agency not found or is inactive.
     """
     file_path = os.path.join(config_dir, file_name)
@@ -49,7 +50,11 @@ def load_urls_from_yaml(
         agency_data = agencies[agency]
         if is_agency_inactive(agency, agency_data):
             raise ValueError(f"Agency '{agency}' is inactive.")
-        return {agency: extract_url(agency_data)}
+        return {agency: {
+            "url": extract_url(agency_data),
+            "scraper_type": agency_data.get("scraper_type", "html"),
+            "active": agency_data.get("active", True),
+        }}
 
     # Load all active agencies
     agency_urls = {}
@@ -59,7 +64,11 @@ def load_urls_from_yaml(
         if is_agency_inactive(agency_key, agency_data):
             inactive_agencies.append(agency_key)
             continue
-        agency_urls[agency_key] = extract_url(agency_data)
+        agency_urls[agency_key] = {
+            "url": extract_url(agency_data),
+            "scraper_type": agency_data.get("scraper_type", "html"),
+            "active": agency_data.get("active", True),
+        }
 
     if inactive_agencies:
         logging.info(

--- a/tests/unit/test_plone6_api_scraper.py
+++ b/tests/unit/test_plone6_api_scraper.py
@@ -1,0 +1,433 @@
+"""
+Unit tests for Plone6APIScraper.
+
+Tests cover: URL building, item transformation, date filtering,
+known URL fence, fetch error handling.
+"""
+import json
+from datetime import datetime, timezone, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from govbr_scraper.scrapers.plone6_api_scraper import Plone6APIScraper
+from govbr_scraper.scrapers.webscraper import ScrapingError
+
+BASE_URL = "https://www.gov.br/susep/pt-br/central-de-conteudos/noticias"
+TZ_BR = timezone(timedelta(hours=-3))
+
+
+def _make_scraper(min_date="2026-01-01", max_date=None, known_urls=None):
+    return Plone6APIScraper(
+        min_date=min_date,
+        base_url=BASE_URL,
+        max_date=max_date,
+        known_urls=known_urls,
+    )
+
+
+def _api_item(url=None, title="Título Teste", effective="2026-03-15T10:00:00-03:00",
+              modified="2026-03-15T10:05:00-03:00", description="Resumo",
+              content="<p>Conteúdo completo</p>"):
+    return {
+        "@id": url or f"https://www.gov.br/susep/pt-br/noticias/{title.lower().replace(' ', '-')}",
+        "title": title,
+        "effective": effective,
+        "modified": modified,
+        "description": description,
+        "text": {"data": content, "content-type": "text/html"},
+    }
+
+
+def _api_response(items, total=None):
+    return {"items": items, "items_total": total or len(items)}
+
+
+class TestGetAgencyName:
+    """Test agency name extraction from URL."""
+
+    def test_extracts_agency_from_govbr_url(self):
+        scraper = _make_scraper()
+        assert scraper.agency == "susep"
+
+    def test_extracts_different_agency(self):
+        scraper = Plone6APIScraper(
+            "2026-01-01",
+            "https://www.gov.br/pncp/pt-br/central-de-conteudo/noticias",
+        )
+        assert scraper.agency == "pncp"
+
+
+class TestBuildApiUrl:
+    """Test URL transformation from base URL to Plone REST API endpoint."""
+
+    def test_inserts_api_segment(self):
+        scraper = _make_scraper()
+        url = scraper._build_api_url(0, 25)
+        assert "++api++" in url
+
+    def test_appends_search_endpoint(self):
+        scraper = _make_scraper()
+        url = scraper._build_api_url(0, 25)
+        assert "/@search" in url
+
+    def test_preserves_agency_path(self):
+        scraper = _make_scraper()
+        url = scraper._build_api_url(0, 25)
+        assert "/susep/++api++" in url
+
+    def test_includes_portal_type_filter(self):
+        scraper = _make_scraper()
+        url = scraper._build_api_url(0, 25)
+        assert "portal_type=News" in url
+
+    def test_pagination_b_start(self):
+        scraper = _make_scraper()
+        url0 = scraper._build_api_url(0, 25)
+        url25 = scraper._build_api_url(25, 25)
+        assert "b_start=0" in url0
+        assert "b_start=25" in url25
+
+    def test_pagination_b_size(self):
+        scraper = _make_scraper()
+        url = scraper._build_api_url(0, 10)
+        assert "b_size=10" in url
+
+    def test_includes_fullobjects(self):
+        scraper = _make_scraper()
+        url = scraper._build_api_url(0, 25)
+        assert "fullobjects=1" in url
+
+
+class TestTransformNewsItem:
+    """Test JSON API item → internal dict transformation."""
+
+    def test_maps_required_fields(self):
+        scraper = _make_scraper()
+        item = _api_item(url="https://www.gov.br/susep/pt-br/noticias/test")
+        published_dt = datetime(2026, 3, 15, 10, 0, tzinfo=TZ_BR)
+        result = scraper._transform_news_item(item, published_dt)
+
+        assert result["url"] == "https://www.gov.br/susep/pt-br/noticias/test"
+        assert result["title"] == "Título Teste"
+        assert result["published_at"] == published_dt
+        assert result["agency"] == "susep"
+
+    def test_extracts_subtitle_from_description(self):
+        scraper = _make_scraper()
+        item = _api_item(description="Resumo da notícia")
+        published_dt = datetime(2026, 3, 15, tzinfo=TZ_BR)
+        result = scraper._transform_news_item(item, published_dt)
+        assert result["subtitle"] == "Resumo da notícia"
+
+    def test_converts_html_content_to_text(self):
+        scraper = _make_scraper()
+        item = _api_item(content="<p>Conteúdo importante aqui</p>")
+        published_dt = datetime(2026, 3, 15, tzinfo=TZ_BR)
+        result = scraper._transform_news_item(item, published_dt)
+        assert "Conteúdo importante aqui" in result["content"]
+
+    def test_extracts_content_from_slate_blocks(self):
+        scraper = _make_scraper()
+        item = {
+            "@id": "https://www.gov.br/susep/pt-br/noticias/test",
+            "title": "Test",
+            "effective": "2026-03-15T10:00:00-03:00",
+            "blocks": {
+                "block-1": {"@type": "slate", "plaintext": "Texto do bloco slate"},
+                "block-2": {"@type": "image"},
+            },
+        }
+        published_dt = datetime(2026, 3, 15, tzinfo=TZ_BR)
+        result = scraper._transform_news_item(item, published_dt)
+        assert "Texto do bloco slate" in result["content"]
+
+    def test_handles_text_field_as_plain_string(self):
+        """When item['text'] is a raw string instead of a dict, use it directly."""
+        scraper = _make_scraper()
+        item = {
+            "@id": "https://www.gov.br/susep/pt-br/noticias/test",
+            "title": "Test",
+            "text": "Conteúdo como string simples",
+        }
+        result = scraper._transform_news_item(item, None)
+        assert "Conteúdo como string simples" in result["content"]
+
+    def test_handles_missing_optional_fields(self):
+        scraper = _make_scraper()
+        item = {
+            "@id": "https://www.gov.br/susep/pt-br/noticias/minimal",
+            "title": "Mínimo",
+        }
+        published_dt = datetime(2026, 3, 15, tzinfo=TZ_BR)
+        result = scraper._transform_news_item(item, published_dt)
+        assert result["subtitle"] is None
+        assert result["content"] == ""
+        assert result["updated_datetime"] is None
+        assert result["image"] is None
+        assert result["category"] == "No Category"
+        assert result["tags"] == []
+
+    def test_handles_none_published_dt(self):
+        scraper = _make_scraper()
+        item = _api_item()
+        result = scraper._transform_news_item(item, None)
+        assert result["published_at"] is None
+
+    def test_includes_extracted_at(self):
+        scraper = _make_scraper()
+        item = _api_item()
+        result = scraper._transform_news_item(item, None)
+        assert result["extracted_at"] is not None
+        assert isinstance(result["extracted_at"], datetime)
+
+    def test_extracts_image_url_from_item(self):
+        scraper = _make_scraper()
+        item = _api_item(url="https://www.gov.br/susep/pt-br/noticias/test")
+        item["image"] = {"download": "@@images/image/large"}
+        published_dt = datetime(2026, 3, 15, tzinfo=TZ_BR)
+        result = scraper._transform_news_item(item, published_dt)
+        assert result["image"] == "https://www.gov.br/susep/pt-br/noticias/@@images/image/large"
+
+    def test_extracts_category_and_tags_from_subject(self):
+        scraper = _make_scraper()
+        item = _api_item()
+        item["Subject"] = ["Economia", "Regulação"]
+        result = scraper._transform_news_item(item, None)
+        assert result["category"] == "Economia"
+        assert result["tags"] == ["Economia", "Regulação"]
+
+    def test_defaults_to_no_category_when_subject_is_not_a_list(self):
+        scraper = _make_scraper()
+        item = _api_item()
+        item["Subject"] = "Economia"  # string instead of list
+        result = scraper._transform_news_item(item, None)
+        assert result["category"] == "No Category"
+        assert result["tags"] == []
+
+    def test_extracts_content_from_text_block_type(self):
+        scraper = _make_scraper()
+        item = {
+            "@id": "https://www.gov.br/susep/pt-br/noticias/test",
+            "title": "Test",
+            "blocks": {
+                "b1": {"@type": "text", "text": "Conteúdo em bloco text"},
+                "b2": {"@type": "textBlock", "text": "Conteúdo em bloco textBlock"},
+            },
+        }
+        result = scraper._transform_news_item(item, None)
+        assert "Conteúdo em bloco text" in result["content"]
+        assert "Conteúdo em bloco textBlock" in result["content"]
+
+    def test_converts_html_in_text_block_to_markdown(self):
+        scraper = _make_scraper()
+        item = {
+            "@id": "https://www.gov.br/susep/pt-br/noticias/test",
+            "title": "Test",
+            "blocks": {
+                "b1": {"@type": "text", "text": "<p>Texto em HTML</p>"},
+            },
+        }
+        result = scraper._transform_news_item(item, None)
+        assert "Texto em HTML" in result["content"]
+
+    def test_invalid_modified_date_produces_none_updated_datetime(self):
+        scraper = _make_scraper()
+        item = _api_item(modified="not-a-date")
+        result = scraper._transform_news_item(item, None)
+        assert result["updated_datetime"] is None
+
+    def test_all_12_fields_present(self):
+        scraper = _make_scraper()
+        item = _api_item()
+        result = scraper._transform_news_item(item, datetime(2026, 3, 15, tzinfo=TZ_BR))
+        expected_fields = {
+            "title", "url", "published_at", "updated_datetime",
+            "category", "tags", "editorial_lead", "subtitle",
+            "content", "image", "agency", "extracted_at",
+        }
+        assert expected_fields.issubset(result.keys())
+
+
+class TestDateFilters:
+    """Test min_date and max_date filtering logic."""
+
+    def test_item_before_min_date_stops_scraping(self):
+        scraper = _make_scraper(min_date="2026-03-10")
+        item = _api_item(effective="2026-03-05T10:00:00-03:00")
+        result = scraper._process_news_item(item)
+        assert result is False
+        assert len(scraper.news_data) == 0
+
+    def test_item_after_max_date_is_skipped_but_continues(self):
+        scraper = _make_scraper(min_date="2026-01-01", max_date="2026-03-15")
+        item = _api_item(effective="2026-03-20T10:00:00-03:00")
+        result = scraper._process_news_item(item)
+        assert result is True  # Continua
+        assert len(scraper.news_data) == 0  # Mas não adiciona
+
+    def test_item_within_range_is_added(self):
+        scraper = _make_scraper(min_date="2026-03-01", max_date="2026-03-31")
+        item = _api_item(effective="2026-03-15T10:00:00-03:00")
+        result = scraper._process_news_item(item)
+        assert result is True
+        assert len(scraper.news_data) == 1
+
+    def test_item_with_invalid_date_is_added(self):
+        """Items with unparseable dates should still be added (not filtered)."""
+        scraper = _make_scraper(min_date="2026-01-01")
+        item = _api_item(effective="not-a-date")
+        result = scraper._process_news_item(item)
+        assert result is True
+        assert len(scraper.news_data) == 1
+
+    def test_item_without_effective_field_is_added(self):
+        """Items with no effective field bypass date filtering and are added."""
+        scraper = _make_scraper(min_date="2026-01-01")
+        item = _api_item()
+        del item["effective"]
+        result = scraper._process_news_item(item)
+        assert result is True
+        assert len(scraper.news_data) == 1
+        assert scraper.news_data[0]["published_at"] is None
+
+
+class TestKnownUrlFence:
+    """Test early-stop optimization when known URLs are encountered."""
+
+    def test_known_url_is_skipped(self):
+        known = {"https://www.gov.br/susep/pt-br/noticias/artigo-1"}
+        scraper = _make_scraper(known_urls=known)
+        item = _api_item(url="https://www.gov.br/susep/pt-br/noticias/artigo-1",
+                         effective="2026-03-15T10:00:00-03:00")
+        result = scraper._process_news_item(item)
+        assert result is True  # Continua (não parou ainda)
+        assert len(scraper.news_data) == 0
+
+    def test_three_consecutive_known_urls_stop_scraping(self):
+        urls = [
+            "https://www.gov.br/susep/pt-br/noticias/artigo-1",
+            "https://www.gov.br/susep/pt-br/noticias/artigo-2",
+            "https://www.gov.br/susep/pt-br/noticias/artigo-3",
+        ]
+        scraper = _make_scraper(known_urls=set(urls))
+        for url in urls[:2]:
+            result = scraper._process_news_item(
+                _api_item(url=url, effective="2026-03-15T10:00:00-03:00")
+            )
+            assert result is True  # Ainda continua
+
+        result = scraper._process_news_item(
+            _api_item(url=urls[2], effective="2026-03-15T10:00:00-03:00")
+        )
+        assert result is False  # Para no 3º consecutivo
+
+    def test_new_url_resets_consecutive_counter(self):
+        known = {
+            "https://www.gov.br/susep/pt-br/noticias/artigo-1",
+            "https://www.gov.br/susep/pt-br/noticias/artigo-2",
+        }
+        scraper = _make_scraper(known_urls=known)
+        # 2 known
+        for url in list(known):
+            scraper._process_news_item(
+                _api_item(url=url, effective="2026-03-15T10:00:00-03:00")
+            )
+        assert scraper._consecutive_known == 2
+        # Novo artigo → reseta contador
+        scraper._process_news_item(
+            _api_item(url="https://www.gov.br/susep/pt-br/noticias/novo",
+                      effective="2026-03-15T10:00:00-03:00")
+        )
+        assert scraper._consecutive_known == 0
+
+
+class TestScrapeNewsLoop:
+    """Test the main pagination loop in scrape_news()."""
+
+    def test_returns_empty_when_api_returns_no_items(self):
+        scraper = _make_scraper()
+        with patch.object(scraper, "_fetch_api_page", return_value=_api_response([])):
+            result = scraper.scrape_news()
+        assert result == []
+
+    def test_processes_single_page(self):
+        scraper = _make_scraper(min_date="2026-03-01", max_date="2026-04-01")
+        items = [_api_item(title=f"Notícia {i}", effective="2026-03-15T10:00:00-03:00")
+                 for i in range(3)]
+        with patch.object(scraper, "_fetch_api_page", return_value=_api_response(items)), \
+             patch("time.sleep"):
+            result = scraper.scrape_news()
+        assert len(result) == 3
+
+    def test_stops_pagination_when_all_items_processed(self):
+        scraper = _make_scraper(min_date="2026-03-01")
+        items = [_api_item(effective="2026-03-15T10:00:00-03:00")]
+        mock_fetch = MagicMock(return_value=_api_response(items, total=1))
+        with patch.object(scraper, "_fetch_api_page", mock_fetch), \
+             patch("time.sleep"):
+            scraper.scrape_news()
+        assert mock_fetch.call_count == 1  # Só 1 página
+
+    def test_stops_early_when_item_before_min_date(self):
+        scraper = _make_scraper(min_date="2026-03-10")
+        items = [_api_item(effective="2026-03-05T10:00:00-03:00")]  # before min_date
+        with patch.object(scraper, "_fetch_api_page",
+                          return_value=_api_response(items, total=100)), \
+             patch("time.sleep"):
+            result = scraper.scrape_news()
+        assert result == []
+
+    def test_paginates_across_multiple_pages(self):
+        scraper = _make_scraper(min_date="2026-03-01", max_date="2026-04-01")
+        page1 = [_api_item(title=f"Notícia {i}", effective="2026-03-15T10:00:00-03:00")
+                 for i in range(3)]
+        page2 = [_api_item(title=f"Notícia {i+3}", effective="2026-03-15T10:00:00-03:00")
+                 for i in range(2)]
+        mock_fetch = MagicMock(side_effect=[
+            _api_response(page1, total=5),
+            _api_response(page2, total=5),
+        ])
+        with patch.object(scraper, "_fetch_api_page", mock_fetch), \
+             patch("time.sleep"):
+            result = scraper.scrape_news()
+        assert mock_fetch.call_count == 2
+        assert len(result) == 5
+
+    def test_propagates_scraping_error(self):
+        scraper = _make_scraper()
+        with patch.object(scraper, "_fetch_api_page",
+                          side_effect=ScrapingError("Falha na API")):
+            with pytest.raises(ScrapingError, match="Falha na API"):
+                scraper.scrape_news()
+
+    def test_wraps_request_exception_as_scraping_error(self):
+        scraper = _make_scraper()
+        with patch.object(scraper, "_fetch_api_page",
+                          side_effect=requests.exceptions.ConnectionError("timeout")):
+            with pytest.raises(ScrapingError, match="Erro de rede"):
+                scraper.scrape_news()
+
+
+class TestFetchApiPage:
+    """Test HTTP fetch and JSON parsing."""
+
+    def test_raises_scraping_error_on_invalid_json(self):
+        scraper = _make_scraper()
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.side_effect = json.JSONDecodeError("err", "doc", 0)
+        with patch("requests.get", return_value=mock_response):
+            with pytest.raises(ScrapingError, match="não-JSON"):
+                scraper._fetch_api_page("https://api.example.com/search")
+
+    def test_returns_parsed_json_on_success(self):
+        scraper = _make_scraper()
+        expected = {"items": [], "items_total": 0}
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = expected
+        with patch("requests.get", return_value=mock_response):
+            result = scraper._fetch_api_page("https://api.example.com/search")
+        assert result == expected

--- a/tests/unit/test_plone6_api_scraper.py
+++ b/tests/unit/test_plone6_api_scraper.py
@@ -181,14 +181,23 @@ class TestTransformNewsItem:
         result = scraper._transform_news_item(item, None)
         assert result["extracted_at"] is not None
         assert isinstance(result["extracted_at"], datetime)
+        assert result["extracted_at"].tzinfo is not None  # timezone-aware (UTC)
 
-    def test_extracts_image_url_from_item(self):
+    def test_extracts_image_url_from_relative_path(self):
         scraper = _make_scraper()
         item = _api_item(url="https://www.gov.br/susep/pt-br/noticias/test")
         item["image"] = {"download": "@@images/image/large"}
         published_dt = datetime(2026, 3, 15, tzinfo=TZ_BR)
         result = scraper._transform_news_item(item, published_dt)
-        assert result["image"] == "https://www.gov.br/susep/pt-br/noticias/@@images/image/large"
+        assert result["image"] == "https://www.gov.br/susep/pt-br/noticias/test/@@images/image/large"
+
+    def test_extracts_image_url_from_absolute_url(self):
+        scraper = _make_scraper()
+        abs_url = "https://www.gov.br/susep/pt-br/noticias/test/@@images/image/large"
+        item = _api_item(url="https://www.gov.br/susep/pt-br/noticias/test")
+        item["image"] = {"download": abs_url}
+        result = scraper._transform_news_item(item, None)
+        assert result["image"] == abs_url
 
     def test_extracts_category_and_tags_from_subject(self):
         scraper = _make_scraper()

--- a/tests/unit/test_scrape_manager_monitoring.py
+++ b/tests/unit/test_scrape_manager_monitoring.py
@@ -20,7 +20,7 @@ class TestScrapeManagerMonitoring:
     @patch("govbr_scraper.scrapers.scrape_manager.WebScraper")
     @patch("govbr_scraper.scrapers.scrape_manager.load_urls_from_yaml")
     def test_records_success_run(self, mock_load, mock_ws_cls):
-        mock_load.return_value = {"mec": "https://www.gov.br/mec"}
+        mock_load.return_value = {"mec": {"url": "https://www.gov.br/mec", "scraper_type": "html", "active": True}}
         mock_scraper = MagicMock()
         mock_scraper.scrape_news.return_value = [
             {"agency": "mec", "title": "Test", "published_at": "2026-01-01", "url": "http://x"}
@@ -43,7 +43,7 @@ class TestScrapeManagerMonitoring:
     def test_records_error_with_classification(self, mock_load, mock_ws_cls):
         from govbr_scraper.scrapers.webscraper import ScrapingError
 
-        mock_load.return_value = {"mec": "https://www.gov.br/mec"}
+        mock_load.return_value = {"mec": {"url": "https://www.gov.br/mec", "scraper_type": "html", "active": True}}
         mock_scraper = MagicMock()
         mock_scraper.scrape_news.side_effect = ScrapingError(
             "Anti-bot protection detected for mec"
@@ -61,7 +61,10 @@ class TestScrapeManagerMonitoring:
     @patch("govbr_scraper.scrapers.scrape_manager.WebScraper")
     @patch("govbr_scraper.scrapers.scrape_manager.load_urls_from_yaml")
     def test_continues_if_tracking_fails(self, mock_load, mock_ws_cls):
-        mock_load.return_value = {"mec": "https://www.gov.br/mec", "mds": "https://www.gov.br/mds"}
+        mock_load.return_value = {
+            "mec": {"url": "https://www.gov.br/mec", "scraper_type": "html", "active": True},
+            "mds": {"url": "https://www.gov.br/mds", "scraper_type": "html", "active": True},
+        }
         mock_scraper = MagicMock()
         mock_scraper.scrape_news.return_value = [
             {"agency": "mec", "title": "Test", "published_at": "2026-01-01", "url": "http://x"}
@@ -84,7 +87,7 @@ class TestScrapeManagerMonitoring:
     @patch("govbr_scraper.scrapers.scrape_manager.WebScraper")
     @patch("govbr_scraper.scrapers.scrape_manager.load_urls_from_yaml")
     def test_measures_execution_time(self, mock_load, mock_ws_cls):
-        mock_load.return_value = {"mec": "https://www.gov.br/mec"}
+        mock_load.return_value = {"mec": {"url": "https://www.gov.br/mec", "scraper_type": "html", "active": True}}
         mock_scraper = MagicMock()
         mock_scraper.scrape_news.return_value = []
         mock_ws_cls.return_value = mock_scraper
@@ -101,7 +104,7 @@ class TestScrapeManagerMonitoring:
     @patch("govbr_scraper.scrapers.scrape_manager.load_urls_from_yaml")
     def test_records_empty_no_error(self, mock_load, mock_ws_cls):
         """0 articles without error = success with articles_scraped=0."""
-        mock_load.return_value = {"mec": "https://www.gov.br/mec"}
+        mock_load.return_value = {"mec": {"url": "https://www.gov.br/mec", "scraper_type": "html", "active": True}}
         mock_scraper = MagicMock()
         mock_scraper.scrape_news.return_value = []  # No articles
         mock_ws_cls.return_value = mock_scraper

--- a/tests/unit/test_scrape_manager_plone6.py
+++ b/tests/unit/test_scrape_manager_plone6.py
@@ -1,0 +1,175 @@
+"""
+Tests for Plone6APIScraper integration in ScrapeManager (Strategy Pattern).
+
+Verifies that ScrapeManager selects the correct scraper based on
+the scraper_type field in the YAML config, and maintains backward
+compatibility for agencies without the field.
+"""
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+from govbr_scraper.scrapers.scrape_manager import ScrapeManager
+from govbr_scraper.scrapers.plone6_api_scraper import Plone6APIScraper
+from govbr_scraper.scrapers.webscraper import WebScraper
+
+
+def _config(url, scraper_type="html"):
+    return {"url": url, "scraper_type": scraper_type, "active": True}
+
+
+def _make_manager():
+    storage = MagicMock()
+    storage.get_recent_urls.return_value = set()
+    storage.insert.return_value = 0
+    return ScrapeManager(storage), storage
+
+
+class TestScraperTypeSelection:
+    """ScrapeManager must pick WebScraper or Plone6APIScraper from config."""
+
+    @patch("govbr_scraper.scrapers.scrape_manager.load_urls_from_yaml")
+    def test_html_type_uses_webscraper(self, mock_load):
+        mock_load.return_value = {"mec": _config("https://www.gov.br/mec/noticias", "html")}
+        manager, _ = _make_manager()
+
+        with patch.object(WebScraper, "__init__", return_value=None) as mock_init, \
+             patch.object(WebScraper, "scrape_news", return_value=[]), \
+             patch.object(Plone6APIScraper, "__init__", return_value=None) as mock_plone_init:
+            manager.run_scraper(agencies=["mec"], min_date="2026-01-01",
+                                max_date="2026-01-31", sequential=True)
+
+        mock_init.assert_called_once()
+        mock_plone_init.assert_not_called()
+
+    @patch("govbr_scraper.scrapers.scrape_manager.load_urls_from_yaml")
+    def test_plone6_api_type_uses_plone6_scraper(self, mock_load):
+        mock_load.return_value = {
+            "susep": _config("https://www.gov.br/susep/noticias", "plone6_api")
+        }
+        manager, _ = _make_manager()
+
+        with patch.object(Plone6APIScraper, "__init__", return_value=None) as mock_init, \
+             patch.object(Plone6APIScraper, "scrape_news", return_value=[]), \
+             patch.object(WebScraper, "__init__", return_value=None) as mock_ws_init:
+            manager.run_scraper(agencies=["susep"], min_date="2026-01-01",
+                                max_date="2026-01-31", sequential=True)
+
+        mock_init.assert_called_once()
+        mock_ws_init.assert_not_called()
+
+    @patch("govbr_scraper.scrapers.scrape_manager.load_urls_from_yaml")
+    def test_mixed_config_uses_both_scrapers(self, mock_load):
+        mock_load.return_value = {
+            "mec":   _config("https://www.gov.br/mec/noticias", "html"),
+            "susep": _config("https://www.gov.br/susep/noticias", "plone6_api"),
+        }
+        manager, _ = _make_manager()
+        ws_instances = []
+        p6_instances = []
+
+        original_ws_init = WebScraper.__init__
+        original_p6_init = Plone6APIScraper.__init__
+
+        def track_ws(self, *a, **kw):
+            ws_instances.append(self)
+            self.news_data = []
+            self.agency = "mec"
+
+        def track_p6(self, *a, **kw):
+            p6_instances.append(self)
+            self.news_data = []
+            self.agency = "susep"
+
+        with patch.object(WebScraper, "__init__", track_ws), \
+             patch.object(WebScraper, "scrape_news", return_value=[]), \
+             patch.object(Plone6APIScraper, "__init__", track_p6), \
+             patch.object(Plone6APIScraper, "scrape_news", return_value=[]):
+            manager.run_scraper(agencies=["mec", "susep"], min_date="2026-01-01",
+                                max_date="2026-01-31", sequential=True)
+
+        assert len(ws_instances) == 1
+        assert len(p6_instances) == 1
+
+
+class TestBackwardCompatibility:
+    """Agencies without scraper_type must default to WebScraper."""
+
+    @patch("govbr_scraper.scrapers.scrape_manager.load_urls_from_yaml")
+    def test_missing_scraper_type_defaults_to_webscraper(self, mock_load):
+        mock_load.return_value = {
+            "mec": {"url": "https://www.gov.br/mec/noticias", "active": True}
+            # scraper_type ausente
+        }
+        manager, _ = _make_manager()
+
+        with patch.object(WebScraper, "__init__", return_value=None) as mock_ws, \
+             patch.object(WebScraper, "scrape_news", return_value=[]), \
+             patch.object(Plone6APIScraper, "__init__", return_value=None) as mock_p6:
+            manager.run_scraper(agencies=["mec"], min_date="2026-01-01",
+                                max_date="2026-01-31", sequential=True)
+
+        mock_ws.assert_called_once()
+        mock_p6.assert_not_called()
+
+
+class TestKnownUrlsPassthrough:
+    """known_urls from storage must be forwarded to whichever scraper is used."""
+
+    @patch("govbr_scraper.scrapers.scrape_manager.load_urls_from_yaml")
+    def test_known_urls_passed_to_webscraper(self, mock_load):
+        mock_load.return_value = {"mec": _config("https://www.gov.br/mec/noticias")}
+        manager, storage = _make_manager()
+        known = {"https://www.gov.br/mec/noticia-1"}
+        storage.get_recent_urls.return_value = known
+
+        with patch.object(WebScraper, "__init__", return_value=None) as mock_init, \
+             patch.object(WebScraper, "scrape_news", return_value=[]):
+            manager.run_scraper(agencies=["mec"], min_date="2026-01-01",
+                                max_date="2026-01-31", sequential=True)
+
+        _, kwargs = mock_init.call_args
+        assert kwargs["known_urls"] == known
+
+    @patch("govbr_scraper.scrapers.scrape_manager.load_urls_from_yaml")
+    def test_known_urls_passed_to_plone6_scraper(self, mock_load):
+        mock_load.return_value = {
+            "susep": _config("https://www.gov.br/susep/noticias", "plone6_api")
+        }
+        manager, storage = _make_manager()
+        known = {"https://www.gov.br/susep/noticia-1"}
+        storage.get_recent_urls.return_value = known
+
+        with patch.object(Plone6APIScraper, "__init__", return_value=None) as mock_init, \
+             patch.object(Plone6APIScraper, "scrape_news", return_value=[]):
+            manager.run_scraper(agencies=["susep"], min_date="2026-01-01",
+                                max_date="2026-01-31", sequential=True)
+
+        _, kwargs = mock_init.call_args
+        assert kwargs["known_urls"] == known
+
+    @patch("govbr_scraper.scrapers.scrape_manager.load_urls_from_yaml")
+    def test_calls_get_recent_urls_with_agency_name(self, mock_load):
+        mock_load.return_value = {"mec": _config("https://www.gov.br/mec/noticias")}
+        manager, storage = _make_manager()
+
+        with patch.object(WebScraper, "__init__", return_value=None), \
+             patch.object(WebScraper, "scrape_news", return_value=[]):
+            manager.run_scraper(agencies=["mec"], min_date="2026-01-01",
+                                max_date="2026-01-31", sequential=True)
+
+        storage.get_recent_urls.assert_called_once_with("mec")
+
+    @patch("govbr_scraper.scrapers.scrape_manager.load_urls_from_yaml")
+    def test_falls_back_to_empty_set_when_storage_fails(self, mock_load):
+        mock_load.return_value = {"mec": _config("https://www.gov.br/mec/noticias")}
+        manager, storage = _make_manager()
+        storage.get_recent_urls.side_effect = Exception("DB down")
+
+        with patch.object(WebScraper, "__init__", return_value=None) as mock_init, \
+             patch.object(WebScraper, "scrape_news", return_value=[]):
+            manager.run_scraper(agencies=["mec"], min_date="2026-01-01",
+                                max_date="2026-01-31", sequential=True)
+
+        _, kwargs = mock_init.call_args
+        assert kwargs["known_urls"] == set()

--- a/tests/unit/test_yaml_config.py
+++ b/tests/unit/test_yaml_config.py
@@ -98,8 +98,8 @@ class TestLoadUrlsFromYamlGovBr:
         config_dir = get_config_dir(_SCRAPERS_MODULE)
         agency_urls = load_urls_from_yaml(config_dir, "site_urls.yaml")
         # cisc uses the generic gov.br/pt-br/noticias URL and is inactive
-        for agency_name, url in agency_urls.items():
-            assert url != "https://www.gov.br/pt-br/noticias"
+        for agency_name, config in agency_urls.items():
+            assert config["url"] != "https://www.gov.br/pt-br/noticias"
 
     def test_load_specific_active_agency(self):
         """Loading a specific active agency should work."""
@@ -107,7 +107,7 @@ class TestLoadUrlsFromYamlGovBr:
         agency_urls = load_urls_from_yaml(config_dir, "site_urls.yaml", agency="mec")
         assert len(agency_urls) == 1
         assert "mec" in agency_urls
-        assert "mec" in agency_urls["mec"]
+        assert "mec" in agency_urls["mec"]["url"]
 
     def test_load_specific_inactive_agency_raises(self):
         """Loading a specific inactive agency should raise ValueError."""
@@ -137,14 +137,14 @@ class TestLoadUrlsFromYamlEBC:
         config_dir = get_config_dir(_SCRAPERS_MODULE)
         agency_urls = load_urls_from_yaml(config_dir, "ebc_urls.yaml")
         # memoria-ebc is inactive, so its URL should not be present
-        for agency_name, url in agency_urls.items():
-            assert "memoria.ebc.com.br" not in url
+        for agency_name, config in agency_urls.items():
+            assert "memoria.ebc.com.br" not in config["url"]
 
     def test_load_urls_includes_active_agencies(self):
         """Active agencies should be in the returned dict."""
         config_dir = get_config_dir(_SCRAPERS_MODULE)
         agency_urls = load_urls_from_yaml(config_dir, "ebc_urls.yaml")
-        urls_str = " ".join(agency_urls.values())
+        urls_str = " ".join(config["url"] for config in agency_urls.values())
         # agencia_brasil and tvbrasil are active
         assert "agenciabrasil.ebc.com.br" in urls_str or "tvbrasil.ebc.com.br" in urls_str
 
@@ -154,7 +154,7 @@ class TestLoadUrlsFromYamlEBC:
         agency_urls = load_urls_from_yaml(config_dir, "ebc_urls.yaml", agency="agencia_brasil")
         assert len(agency_urls) == 1
         assert "agencia_brasil" in agency_urls
-        assert "agenciabrasil.ebc.com.br" in agency_urls["agencia_brasil"]
+        assert "agenciabrasil.ebc.com.br" in agency_urls["agencia_brasil"]["url"]
 
     def test_load_specific_inactive_agency_raises(self):
         """Loading a specific inactive agency should raise ValueError."""
@@ -167,3 +167,60 @@ class TestLoadUrlsFromYamlEBC:
         config_dir = get_config_dir(_SCRAPERS_MODULE)
         with pytest.raises(ValueError, match="not found"):
             load_urls_from_yaml(config_dir, "ebc_urls.yaml", agency="nonexistent_agency_xyz")
+
+
+class TestLoadUrlsReturnsConfigDict:
+    """Tests for the dict structure returned by load_urls_from_yaml."""
+
+    def test_values_are_dicts_not_strings(self):
+        """Each value in the returned dict must be a config dict, not a URL string."""
+        config_dir = get_config_dir(_SCRAPERS_MODULE)
+        agency_urls = load_urls_from_yaml(config_dir, "site_urls.yaml")
+        for agency_name, config in agency_urls.items():
+            assert isinstance(config, dict), f"{agency_name}: expected dict, got {type(config)}"
+
+    def test_config_dict_has_url_field(self):
+        """Each config dict must contain a 'url' key."""
+        config_dir = get_config_dir(_SCRAPERS_MODULE)
+        agency_urls = load_urls_from_yaml(config_dir, "site_urls.yaml", agency="mec")
+        assert "url" in agency_urls["mec"]
+        assert "mec" in agency_urls["mec"]["url"]
+
+    def test_config_dict_has_scraper_type_field(self):
+        """Each config dict must contain a 'scraper_type' key."""
+        config_dir = get_config_dir(_SCRAPERS_MODULE)
+        agency_urls = load_urls_from_yaml(config_dir, "site_urls.yaml")
+        for agency_name, config in agency_urls.items():
+            assert "scraper_type" in config, f"{agency_name} missing scraper_type"
+
+    def test_plone6_agencies_have_correct_scraper_type(self):
+        """Plone 6 agencies must be configured with scraper_type=plone6_api."""
+        plone6_agencies = ["susep", "patrimonio", "propriedade-intelectual", "pncp"]
+        config_dir = get_config_dir(_SCRAPERS_MODULE)
+        for agency in plone6_agencies:
+            result = load_urls_from_yaml(config_dir, "site_urls.yaml", agency=agency)
+            assert result[agency]["scraper_type"] == "plone6_api", \
+                f"{agency} should have scraper_type=plone6_api"
+
+    def test_regular_agencies_default_to_html_scraper_type(self):
+        """Agencies without explicit scraper_type must default to 'html'."""
+        config_dir = get_config_dir(_SCRAPERS_MODULE)
+        result = load_urls_from_yaml(config_dir, "site_urls.yaml", agency="mec")
+        assert result["mec"]["scraper_type"] == "html"
+
+    def test_scraper_type_values_are_valid(self):
+        """All scraper_type values must be within the known set."""
+        valid_types = {"html", "plone6_api"}
+        config_dir = get_config_dir(_SCRAPERS_MODULE)
+        agency_urls = load_urls_from_yaml(config_dir, "site_urls.yaml")
+        for agency_name, config in agency_urls.items():
+            assert config["scraper_type"] in valid_types, \
+                f"{agency_name}: unknown scraper_type '{config['scraper_type']}'"
+
+    def test_config_dict_has_active_field(self):
+        """Each config dict must contain an 'active' key set to True (inactive filtered out)."""
+        config_dir = get_config_dir(_SCRAPERS_MODULE)
+        agency_urls = load_urls_from_yaml(config_dir, "site_urls.yaml")
+        for agency_name, config in agency_urls.items():
+            assert "active" in config, f"{agency_name} missing active field"
+            assert config["active"] is True, f"{agency_name}: active should be True (inactive are filtered)"


### PR DESCRIPTION
## Problema

Fecha #30. 263 falhas diárias de scraping concentradas em agências gov.br que migraram para **Plone 6 + Volto (React SPA)**. O conteúdo é renderizado client-side via JavaScript — `requests` + `BeautifulSoup` recebem HTML vazio.

Agências afetadas: `susep`, `patrimonio`, `propriedade-intelectual`, `pncp`, `sri` (URL errada) e mais 7 desabilitadas por esse mesmo motivo.

## Solução

- **`Plone6APIScraper`**: usa a REST API nativa do Plone (`++api++/@search`) com `fullobjects=1`, retornando JSON com conteúdo completo — sem depender de renderização JS
- **Strategy Pattern**: campo `scraper_type` no YAML seleciona o scraper em runtime; default `"html"` garante backward compatibility para as ~150 agências existentes
- **Sem mudanças em DAGs ou API**: seleção acontece no `ScrapeManager`

## Mudanças

- `plone6_api_scraper.py` — novo scraper (paginação, retry, known URL fence, extração de slate/text blocks)
- `scrape_manager.py` — Strategy Pattern via `scraper_type`
- `yaml_config.py` — retorna `dict` com `url`, `scraper_type` e `active` (era string)
- `site_urls.yaml` — `scraper_type: plone6_api` para 4 agências; URL da SRI corrigida; 7 agências Volto reativadas (ctav, esg, esporte, hfa, memp, povosindigenas, reconstrucaors)

## Testes

- `test_plone6_api_scraper.py` — 33 testes, **100% de cobertura**
- `test_scrape_manager_plone6.py` — 8 testes (seleção de scraper, passagem de known_urls, fallback)
- `test_yaml_config.py` — atualizado + 6 testes novos para estrutura do dict
- 301 testes passando, sem regressões