### PR TITLE
refactor: revisar e complementar testes de integração (issue #34)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,3 +84,6 @@ addopts = [
     "--cov=govbr_scraper",
     "--cov-report=term-missing",
 ]
+markers = [
+    "integration: tests that make real HTTP requests to external services",
+]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,79 @@
+"""
+Integration test configuration and fixtures.
+
+Provides skip-count enforcement to prevent silent test failures when network is unavailable.
+"""
+
+import pytest
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """
+    Warn if too many integration tests were skipped.
+
+    Integration tests make real HTTP requests and can skip due to network issues.
+    If >50% of integration tests skip, it likely indicates a systemic problem
+    (network down, firewall blocking, gov.br maintenance) rather than individual
+    test issues. Fail the test run to prevent false positives.
+    """
+    if session.config.getoption("--collect-only"):
+        return
+
+    integration_skipped = 0
+    integration_passed = 0
+    integration_failed = 0
+    integration_total = 0
+
+    for item in session.items:
+        if item.get_closest_marker("integration"):
+            integration_total += 1
+
+            # Skips can occur in setup phase (fixture calls pytest.skip) or call phase
+            setup_skipped = hasattr(item, "rep_setup") and item.rep_setup.skipped
+            call_skipped = hasattr(item, "rep_call") and item.rep_call.skipped
+
+            if setup_skipped or call_skipped:
+                integration_skipped += 1
+            elif hasattr(item, "rep_call") and item.rep_call.passed:
+                integration_passed += 1
+            elif hasattr(item, "rep_call") and item.rep_call.failed:
+                integration_failed += 1
+
+    # If we haven't run yet, check during collection (for --collect-only compatibility)
+    if integration_total == 0:
+        return
+
+    if integration_total > 0:
+        skip_percentage = (integration_skipped / integration_total) * 100
+
+        # Print summary
+        print("\n" + "=" * 70)
+        print("INTEGRATION TEST SUMMARY")
+        print("=" * 70)
+        print(f"Total:   {integration_total}")
+        print(f"Passed:  {integration_passed}")
+        print(f"Failed:  {integration_failed}")
+        print(f"Skipped: {integration_skipped} ({skip_percentage:.1f}%)")
+        print("=" * 70)
+
+        # Fail if too many skips
+        if skip_percentage > 50:
+            pytest.exit(
+                f"\nFAIL: {skip_percentage:.1f}% of integration tests were skipped "
+                f"({integration_skipped}/{integration_total}).\n"
+                f"This likely indicates network unavailability or gov.br maintenance.\n"
+                f"Integration tests require real HTTP access to validate behavior.",
+                returncode=1,
+            )
+
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    """
+    Store test results on items so pytest_sessionfinish can access them.
+    """
+    outcome = yield
+    rep = outcome.get_result()
+
+    # Store report by phase
+    setattr(item, f"rep_{rep.when}", rep)

--- a/tests/integration/test_affected_agencies.py
+++ b/tests/integration/test_affected_agencies.py
@@ -42,9 +42,9 @@ WORKING_AGENCY = {
 # Agencies that work with BeautifulSoup (traditional HTML templates)
 SCRAPABLE_AGENCIES = {key: _ALL_URLS[key]["url"] for key in _SCRAPABLE_AGENCY_KEYS}
 
-# Agencies that use Plone6 REST API (scraper_type: plone6_api)
-# Covered by test_plone6_integration.py, not tested here
-PLONE6_AGENCIES = {"ctav", "esg", "esporte", "hfa", "memp", "reconstrucaors"}
+# Agencies with scraper_type: plone6_api (ctav, esg, esporte, hfa, memp,
+# patrimonio, pncp, povosindigenas, propriedade-intelectual, reconstrucaors, susep)
+# are covered by test_plone6_integration.py, not tested here.
 
 HEADERS = {
     "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",

--- a/tests/integration/test_affected_agencies.py
+++ b/tests/integration/test_affected_agencies.py
@@ -7,50 +7,44 @@ by making real HTTP requests to the gov.br pages.
 These tests:
 1. Fetch real pages from affected agencies
 2. Validate the scraper finds articles (core fix for Issue #19)
-3. Validate extraction of title, url, date
-4. Compare with a working agency (mec) to ensure same data structure
+3. Validate extraction of title, url, date using production WebScraper code
 """
 
 import pytest
 import requests
 from datetime import date, datetime
-from bs4 import BeautifulSoup
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 from govbr_scraper.scrapers.webscraper import WebScraper
+from govbr_scraper.scrapers.yaml_config import load_urls_from_yaml
 
 
 # =============================================================================
 # Configuration
 # =============================================================================
 
+_CONFIG_DIR = str(Path(__file__).parent.parent.parent / "src" / "govbr_scraper" / "scrapers" / "config")
+_ALL_URLS = load_urls_from_yaml(_CONFIG_DIR, "site_urls.yaml")
+
+# Opt-in: only agencies explicitly listed here are used in integration tests.
+# Adding an agency to site_urls.yaml does NOT automatically add it here.
+_WORKING_AGENCY_KEY = "mec"
+
+# Agencies that work with BeautifulSoup (traditional HTML templates, scraper_type: html)
+_SCRAPABLE_AGENCY_KEYS = ["palmares", "sudam", "cemaden", "semanaenef", "sri", "ctir"]
+
 # Working agency for baseline comparison
 WORKING_AGENCY = {
-    "key": "mec",
-    "url": "https://www.gov.br/mec/pt-br/assuntos/noticias",
+    "key": _WORKING_AGENCY_KEY,
+    "url": _ALL_URLS[_WORKING_AGENCY_KEY]["url"],
 }
 
 # Agencies that work with BeautifulSoup (traditional HTML templates)
-SCRAPABLE_AGENCIES = {
-    "palmares": "https://www.gov.br/palmares/pt-br/assuntos/noticias",
-    "sudam": "https://www.gov.br/sudam/pt-br/noticias-1",
-    "cemaden": "https://www.gov.br/cemaden/pt-br/assuntos/noticias-cemaden/ultimas-noticias",
-    "semanaenef": "https://www.gov.br/semanaenef/pt-br/noticias",
-    "sri": "https://www.gov.br/sri/pt-br/noticias/mais-noticias/ultimas-noticias",
-}
+SCRAPABLE_AGENCIES = {key: _ALL_URLS[key]["url"] for key in _SCRAPABLE_AGENCY_KEYS}
 
-# Agencies that use Volto/SPA (require JavaScript to render content)
-# These cannot be scraped with BeautifulSoup - require Playwright/Selenium
-SPA_AGENCIES = {
-    "ctir": "https://www.gov.br/ctir/pt-br/assuntos/noticias",
-    "esporte": "https://www.gov.br/esporte/pt-br/noticias-e-conteudos/esporte",
-    "hfa": "https://www.gov.br/hfa/pt-br/noticias",
-    "memp": "https://www.gov.br/memp/pt-br/assuntos/noticias",
-    "reconstrucaors": "https://www.gov.br/reconstrucaors/pt-br/acompanhe-a-reconstrucao/noticias",
-    "esg": "https://www.gov.br/esg/pt-br/centrais-de-conteudo/noticias",
-    "ctav": "https://www.gov.br/ctav/pt-br/noticias",
-}
-
-# All agencies combined (for reference/reporting)
-AFFECTED_AGENCIES = {**SCRAPABLE_AGENCIES, **SPA_AGENCIES}
+# Agencies that use Plone6 REST API (scraper_type: plone6_api)
+# Covered by test_plone6_integration.py, not tested here
+PLONE6_AGENCIES = {"ctav", "esg", "esporte", "hfa", "memp", "reconstrucaors"}
 
 HEADERS = {
     "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
@@ -85,9 +79,9 @@ def working_agency_data():
 
 @pytest.fixture(scope="module")
 def affected_agencies_data():
-    """Fetch and parse pages from all affected agencies."""
+    """Fetch and parse pages from scrapable agencies used in tests."""
     data = {}
-    for agency_key, url in AFFECTED_AGENCIES.items():
+    for agency_key, url in SCRAPABLE_AGENCIES.items():
         try:
             response = requests.get(url, headers=HEADERS, timeout=REQUEST_TIMEOUT)
             response.raise_for_status()
@@ -102,37 +96,6 @@ def create_scraper(base_url: str) -> WebScraper:
     return WebScraper(base_url=base_url, min_date="2020-01-01")
 
 
-def find_news_items(html_content: bytes) -> list:
-    """
-    Find news items using the same fallback chain as webscraper.py.
-    This mirrors the logic in scrape_page_of_news after the fix.
-    """
-    soup = BeautifulSoup(html_content, "html.parser")
-
-    # Strategy 1: article.tileItem (main pattern)
-    news_items = soup.find_all("article", class_="tileItem")
-
-    # Fallback 1: ul.noticias > li
-    if not news_items:
-        news_list = soup.find("ul", class_="noticias")
-        if news_list:
-            news_items = news_list.find_all("li")
-
-    # Fallback 2: article.entry inside div.entries (SUDAM, CTIR, etc.)
-    if not news_items:
-        entries_container = soup.find("div", class_="entries")
-        if entries_container:
-            news_items = entries_container.find_all("article", class_="entry")
-
-    # Fallback 3: div.item in content-core (Palmares, HFA, etc.)
-    if not news_items:
-        content_core = soup.find("div", id="content-core")
-        if content_core:
-            news_items = content_core.find_all("div", class_="item")
-
-    return news_items
-
-
 # =============================================================================
 # Tests - Scraper Finds Articles (Core Fix for Issue #19)
 # =============================================================================
@@ -141,7 +104,8 @@ def find_news_items(html_content: bytes) -> list:
 @pytest.mark.integration
 class TestScraperFindsArticles:
     """
-    Core test: Verify that the scraper finds articles on scrapable agencies.
+    Core test: Verify that the scraper finds articles on scrapable agencies
+    using the production WebScraper.scrape_page() code.
 
     Before the fix, these agencies returned 0 articles with large response sizes,
     causing ScrapingError. After the fix, articles should be found.
@@ -157,10 +121,19 @@ class TestScraperFindsArticles:
         if "error" in page_data:
             pytest.skip(f"Could not fetch {agency_key}: {page_data['error']}")
 
-        news_items = find_news_items(page_data["html"])
-        response_size = len(page_data["html"])
+        scraper = create_scraper(SCRAPABLE_AGENCIES[agency_key])
 
-        assert len(news_items) > 0, (
+        # Mock fetch_page to inject pre-fetched HTML
+        mock_response = MagicMock()
+        mock_response.content = page_data["html"]
+        mock_response.url = page_data["url"]
+
+        with patch.object(scraper, 'fetch_page', return_value=mock_response):
+            # Use production scrape_page() which includes proper Fallback 3 filtering
+            should_continue, items_count = scraper.scrape_page(page_data["url"])
+
+        response_size = len(page_data["html"])
+        assert items_count > 0, (
             f"ISSUE #19 NOT FIXED: No articles found for {agency_key}. "
             f"Response size: {response_size} bytes. "
             f"This would cause ScrapingError in production."
@@ -168,8 +141,16 @@ class TestScraperFindsArticles:
 
     def test_working_agency_still_works(self, working_agency_data):
         """Baseline: working agency (mec) should continue to find articles."""
-        news_items = find_news_items(working_agency_data["html"])
-        assert len(news_items) > 0, "Working agency should find articles"
+        scraper = create_scraper(WORKING_AGENCY["url"])
+
+        mock_response = MagicMock()
+        mock_response.content = working_agency_data["html"]
+        mock_response.url = working_agency_data["url"]
+
+        with patch.object(scraper, 'fetch_page', return_value=mock_response):
+            should_continue, items_count = scraper.scrape_page(working_agency_data["url"])
+
+        assert items_count > 0, "Working agency should find articles"
 
 
 # =============================================================================
@@ -183,6 +164,8 @@ class TestScraperExtractsFields:
     Verify that the scraper extracts the same fields from scrapable agencies
     that it extracts from working agencies: title, url, date.
 
+    Uses production WebScraper code to ensure real extraction logic is tested.
+
     Note: SPA agencies are excluded as they require JavaScript.
     """
 
@@ -194,15 +177,33 @@ class TestScraperExtractsFields:
         if "error" in page_data:
             pytest.skip(f"Could not fetch {agency_key}: {page_data['error']}")
 
-        news_items = find_news_items(page_data["html"])
-        if not news_items:
-            pytest.skip(f"No articles found for {agency_key}")
-
         scraper = create_scraper(SCRAPABLE_AGENCIES[agency_key])
+
+        # Mock fetch_page and extract_news_info to get parsed items
+        mock_response = MagicMock()
+        mock_response.content = page_data["html"]
+        mock_response.url = page_data["url"]
+
+        # Track extracted items by mocking extract_news_info
+        extracted_items = []
+
+        def mock_extract_news_info(item):
+            # Store the item for testing
+            extracted_items.append(item)
+            # Return True to continue processing (don't stop early)
+            # In production, this would fetch article content and check dates
+            return True
+
+        with patch.object(scraper, 'fetch_page', return_value=mock_response):
+            with patch.object(scraper, 'extract_news_info', side_effect=mock_extract_news_info):
+                scraper.scrape_page(page_data["url"])
+
+        if not extracted_items:
+            pytest.skip(f"No articles found for {agency_key}")
 
         # Check first 5 items for valid titles (some may be images without text)
         valid_titles = 0
-        for item in news_items[:5]:
+        for item in extracted_items[:5]:
             title, url = scraper.extract_title_and_url(item)
             if title != "No Title" and len(title.strip()) > 0:
                 valid_titles += 1
@@ -217,15 +218,29 @@ class TestScraperExtractsFields:
         if "error" in page_data:
             pytest.skip(f"Could not fetch {agency_key}: {page_data['error']}")
 
-        news_items = find_news_items(page_data["html"])
-        if not news_items:
-            pytest.skip(f"No articles found for {agency_key}")
-
         scraper = create_scraper(SCRAPABLE_AGENCIES[agency_key])
+
+        # Mock fetch_page and extract_news_info to get parsed items
+        mock_response = MagicMock()
+        mock_response.content = page_data["html"]
+        mock_response.url = page_data["url"]
+
+        extracted_items = []
+
+        def mock_extract_news_info(item):
+            extracted_items.append(item)
+            return True
+
+        with patch.object(scraper, 'fetch_page', return_value=mock_response):
+            with patch.object(scraper, 'extract_news_info', side_effect=mock_extract_news_info):
+                scraper.scrape_page(page_data["url"])
+
+        if not extracted_items:
+            pytest.skip(f"No articles found for {agency_key}")
 
         # Check first 5 articles for dates
         dates_extracted = 0
-        for item in news_items[:5]:
+        for item in extracted_items[:5]:
             extracted_date = scraper.extract_date(item)
             if extracted_date is not None:
                 dates_extracted += 1
@@ -235,141 +250,3 @@ class TestScraperExtractsFields:
         assert dates_extracted > 0, (
             f"{agency_key}: Could not extract date from any of the first 5 articles"
         )
-
-
-# =============================================================================
-# Tests - Comparison with Working Agency
-# =============================================================================
-
-
-@pytest.mark.integration
-class TestComparisonWithWorkingAgency:
-    """Compare affected agencies with working agency to ensure same data quality."""
-
-    def test_working_agency_extracts_all_fields(self, working_agency_data):
-        """Baseline: working agency extracts title, url, and date."""
-        news_items = find_news_items(working_agency_data["html"])
-        assert len(news_items) > 0
-
-        scraper = create_scraper(WORKING_AGENCY["url"])
-        item = news_items[0]
-
-        title, url = scraper.extract_title_and_url(item)
-        extracted_date = scraper.extract_date(item)
-
-        assert title != "No Title", "Working agency should extract title"
-        assert url != "No URL", "Working agency should extract URL"
-        assert extracted_date is not None, "Working agency should extract date"
-
-    @pytest.mark.parametrize("agency_key", ["palmares", "sudam"])
-    def test_scrapable_agency_matches_working_quality(
-        self, affected_agencies_data, working_agency_data, agency_key
-    ):
-        """Scrapable agencies should extract data with same quality as working agency."""
-        page_data = affected_agencies_data.get(agency_key)
-
-        if "error" in page_data:
-            pytest.skip(f"Could not fetch {agency_key}: {page_data['error']}")
-
-        # Get working agency data
-        working_items = find_news_items(working_agency_data["html"])
-        working_scraper = create_scraper(WORKING_AGENCY["url"])
-        working_title, working_url = working_scraper.extract_title_and_url(working_items[0])
-        working_date = working_scraper.extract_date(working_items[0])
-
-        # Get affected agency data
-        affected_items = find_news_items(page_data["html"])
-        if not affected_items:
-            pytest.skip(f"No articles found for {agency_key}")
-
-        affected_scraper = create_scraper(SCRAPABLE_AGENCIES[agency_key])
-        affected_title, affected_url = affected_scraper.extract_title_and_url(affected_items[0])
-
-        # Compare: both should have valid data
-        assert (working_title != "No Title") == (affected_title != "No Title"), (
-            f"{agency_key} should extract title like working agency"
-        )
-        assert (working_url != "No URL") == (affected_url != "No URL"), (
-            f"{agency_key} should extract URL like working agency"
-        )
-
-
-# =============================================================================
-# Tests - Extraction Functions (Isolated)
-# =============================================================================
-
-
-@pytest.mark.integration
-class TestExtractionFunctions:
-    """Test the new extraction functions with real data."""
-
-    def test_extract_date_3_on_article_container(self, affected_agencies_data):
-        """Test extract_date_3 works on article-container pattern (palmares)."""
-        page_data = affected_agencies_data.get("palmares")
-
-        if "error" in page_data:
-            pytest.skip("Could not fetch palmares")
-
-        soup = BeautifulSoup(page_data["html"], "html.parser")
-        article_containers = soup.find_all("div", class_="article-container")
-
-        if not article_containers:
-            pytest.skip("No article-container found on palmares")
-
-        scraper = create_scraper(SCRAPABLE_AGENCIES["palmares"])
-
-        # Test extract_date_3 directly
-        for item in article_containers[:3]:
-            result = scraper.extract_date_3(item)
-            if result is not None:
-                assert isinstance(result, datetime)
-                return  # Found at least one date
-
-        # It's OK if some pages don't have dates in this format
-        pytest.skip("No dates found with extract_date_3 pattern")
-
-
-# =============================================================================
-# Summary Report (runs last)
-# =============================================================================
-
-
-@pytest.mark.integration
-class TestSummaryReport:
-    """Generate a summary report of all affected agencies."""
-
-    def test_generate_report(self, affected_agencies_data):
-        """Print extraction results for all affected agencies."""
-        print("\n" + "=" * 70)
-        print("ISSUE #19 FIX VALIDATION REPORT")
-        print("=" * 70)
-
-        success = 0
-        fail = 0
-
-        for agency_key, page_data in affected_agencies_data.items():
-            if "error" in page_data:
-                print(f"{agency_key}: SKIP (network error)")
-                continue
-
-            news_items = find_news_items(page_data["html"])
-
-            if not news_items:
-                print(f"{agency_key}: FAIL (0 articles found)")
-                fail += 1
-                continue
-
-            scraper = create_scraper(AFFECTED_AGENCIES[agency_key])
-            item = news_items[0]
-            title, url = scraper.extract_title_and_url(item)
-            extracted_date = scraper.extract_date(item)
-
-            status = "OK" if title != "No Title" else "PARTIAL"
-            print(f"{agency_key}: {status} ({len(news_items)} articles)")
-            print(f"  Title: {title[:50]}..." if len(title) > 50 else f"  Title: {title}")
-            print(f"  Date: {extracted_date}")
-            success += 1
-
-        print("=" * 70)
-        print(f"RESULT: {success} OK, {fail} FAIL")
-        print("=" * 70)

--- a/tests/integration/test_ebc_integration.py
+++ b/tests/integration/test_ebc_integration.py
@@ -204,8 +204,10 @@ class TestEBCWebScraper:
 
             try:
                 article_urls = scraper.scrape_index_page(base_url)
+            except requests.exceptions.RequestException as e:
+                pytest.skip(f"Failed to fetch {agency_key} index page (network issue): {e}")
             except Exception as e:
-                pytest.skip(f"Failed to fetch {agency_key} index page: {e}")
+                pytest.fail(f"scrape_index_page() raised unexpected error for {agency_key}: {e}")
 
             # Should find articles with any of the 3 strategies
             assert len(article_urls) > 0, (

--- a/tests/integration/test_ebc_integration.py
+++ b/tests/integration/test_ebc_integration.py
@@ -1,0 +1,219 @@
+"""
+Integration tests for EBCWebScraper against real EBC sites.
+
+Tests the EBCWebScraper with real HTTP requests to validate that:
+- Agencia Brasil and TV Brasil index pages can be scraped
+- Article extraction works correctly for both sources
+- Different parsing strategies (_scrape_agencia_brasil_content vs _scrape_tvbrasil_content) work
+"""
+
+import pytest
+import requests
+from datetime import datetime
+from pathlib import Path
+from govbr_scraper.scrapers.ebc_webscraper import EBCWebScraper
+from govbr_scraper.scrapers.yaml_config import load_urls_from_yaml
+
+
+@pytest.fixture(scope="module")
+def ebc_urls():
+    """Load EBC URLs from YAML configuration."""
+    config_dir = str(Path(__file__).parent.parent.parent / "src" / "govbr_scraper" / "scrapers" / "config")
+
+    try:
+        urls = load_urls_from_yaml(config_dir, "ebc_urls.yaml")
+    except Exception as e:
+        pytest.skip(f"Could not load ebc_urls.yaml: {e}")
+
+    return urls
+
+
+@pytest.mark.integration
+class TestEBCWebScraper:
+    """Test EBCWebScraper against real EBC sites."""
+
+    def test_agencia_brasil_extracts_article(self, ebc_urls):
+        """
+        Agencia Brasil should extract title, content, source, published_datetime.
+
+        This test validates:
+        - Index page scraping works (scrape_index_page)
+        - Article page scraping works (scrape_news_page)
+        - _scrape_agencia_brasil_content extracts all expected fields
+        - Published datetime is valid
+        """
+        if "agencia_brasil" not in ebc_urls:
+            pytest.skip("agencia_brasil not found in ebc_urls.yaml")
+
+        base_url = ebc_urls["agencia_brasil"]["url"]
+        scraper = EBCWebScraper(base_url=base_url, min_date="2020-01-01")
+
+        # Step 1: Fetch index page to get article URLs
+        try:
+            article_urls = scraper.scrape_index_page(base_url)
+        except requests.exceptions.RequestException as e:
+            pytest.skip(f"Failed to fetch Agencia Brasil index page (network issue): {e}")
+        except Exception as e:
+            pytest.fail(f"scrape_index_page() raised unexpected error: {e}")
+
+        assert len(article_urls) > 0, (
+            "No article URLs found on Agencia Brasil index page. "
+            "This may indicate HTML structure changes."
+        )
+
+        # Validate URL structure
+        first_url = article_urls[0]
+        assert first_url.startswith("https://"), f"Article URL should be absolute HTTPS, got {first_url}"
+        assert "agenciabrasil.ebc.com.br" in first_url, (
+            f"Article URL should be from agenciabrasil.ebc.com.br domain, got {first_url}"
+        )
+
+        # Step 2: Fetch first article page
+        try:
+            article_data = scraper.scrape_news_page(first_url)
+        except requests.exceptions.RequestException as e:
+            pytest.skip(f"Failed to fetch article page (network issue): {e}")
+        except Exception as e:
+            pytest.fail(f"scrape_news_page() raised unexpected error: {e}")
+
+        # Should not have error message if successful (error field may exist but be empty)
+        if article_data.get("error"):
+            pytest.fail(f"Article extraction failed with error: {article_data['error']}")
+
+        # Validate required fields for Agencia Brasil
+        assert "title" in article_data, "title field is missing"
+        assert article_data["title"], "title is empty"
+        assert isinstance(article_data["title"], str), f"title should be str, got {type(article_data['title'])}"
+
+        assert "content" in article_data, "content field is missing"
+        assert article_data["content"], "content is empty"
+        assert isinstance(article_data["content"], str), (
+            f"content should be str, got {type(article_data['content'])}"
+        )
+        # Content should have meaningful length (not just whitespace)
+        assert len(article_data["content"].strip()) > 50, (
+            f"content seems too short ({len(article_data['content'])} chars), may indicate extraction failure"
+        )
+
+        assert "published_datetime" in article_data, "published_datetime field is missing"
+        assert article_data["published_datetime"], "published_datetime is None"
+        assert isinstance(article_data["published_datetime"], datetime), (
+            f"published_datetime should be datetime, got {type(article_data['published_datetime'])}"
+        )
+
+        # Validate datetime is in reasonable range
+        year = article_data["published_datetime"].year
+        current_year = datetime.now().year
+        assert 2020 <= year <= current_year + 1, (
+            f"published_datetime year {year} is outside reasonable range (2020-{current_year + 1})"
+        )
+
+        # Agencia Brasil specific field: source (author)
+        assert "source" in article_data, "source field is missing (Agencia Brasil should extract author)"
+        # Note: source may be empty for some articles, so we just check it exists
+
+        assert "agency" in article_data, "agency field is missing"
+        assert article_data["agency"] == "agencia_brasil", (
+            f"agency should be 'agencia_brasil', got {article_data['agency']}"
+        )
+
+    def test_tv_brasil_extracts_article(self, ebc_urls):
+        """
+        TV Brasil should extract title, content, editorial_lead (program name).
+
+        This test validates:
+        - Index page scraping works for TV Brasil
+        - Article page scraping works with _scrape_tvbrasil_content
+        - Editorial lead (program name) is extracted correctly
+        """
+        if "tvbrasil" not in ebc_urls:
+            pytest.skip("tvbrasil not found in ebc_urls.yaml")
+
+        base_url = ebc_urls["tvbrasil"]["url"]
+        scraper = EBCWebScraper(base_url=base_url, min_date="2020-01-01")
+
+        # Step 1: Fetch index page
+        try:
+            article_urls = scraper.scrape_index_page(base_url)
+        except requests.exceptions.RequestException as e:
+            pytest.skip(f"Failed to fetch TV Brasil index page (network issue): {e}")
+        except Exception as e:
+            pytest.fail(f"scrape_index_page() raised unexpected error: {e}")
+
+        assert len(article_urls) > 0, (
+            "No article URLs found on TV Brasil index page. "
+            "This may indicate HTML structure changes."
+        )
+
+        # Validate URL structure
+        first_url = article_urls[0]
+        assert first_url.startswith("https://"), f"Article URL should be absolute HTTPS, got {first_url}"
+        assert "tvbrasil.ebc.com.br" in first_url, (
+            f"Article URL should be from tvbrasil.ebc.com.br domain, got {first_url}"
+        )
+
+        # Step 2: Fetch first article page
+        try:
+            article_data = scraper.scrape_news_page(first_url)
+        except requests.exceptions.RequestException as e:
+            pytest.skip(f"Failed to fetch TV Brasil article (network issue): {e}")
+        except Exception as e:
+            pytest.fail(f"scrape_news_page() raised unexpected error: {e}")
+
+        # Should not have error message if successful (error field may exist but be empty)
+        if article_data.get("error"):
+            pytest.fail(f"Article extraction failed with error: {article_data['error']}")
+
+        # Validate required fields
+        assert "title" in article_data, "title field is missing"
+        assert article_data["title"], "title is empty"
+
+        assert "content" in article_data, "content field is missing"
+        assert article_data["content"], "content is empty"
+        assert len(article_data["content"].strip()) > 50, (
+            f"content seems too short ({len(article_data['content'])} chars)"
+        )
+
+        # TV Brasil specific field: editorial_lead (program name)
+        # The field must exist in the response; value may be empty for some articles
+        assert "editorial_lead" in article_data, (
+            "editorial_lead field is missing (TV Brasil should extract program name)"
+        )
+
+        assert "agency" in article_data, "agency field is missing"
+        assert article_data["agency"] == "tvbrasil", (
+            f"agency should be 'tvbrasil', got {article_data['agency']}"
+        )
+
+    def test_index_page_strategies(self, ebc_urls):
+        """
+        scrape_index_page() should handle different HTML structures.
+
+        This test validates that the 3 index page strategies work:
+        - Strategy 1: a.capa-noticia (Agencia Brasil)
+        - Strategy 2: memoria.ebc legacy format
+        - Strategy 3: view-ultimas (TV Brasil)
+        """
+        # Test both active EBC sources
+        for agency_key in ["agencia_brasil", "tvbrasil"]:
+            if agency_key not in ebc_urls:
+                continue
+
+            base_url = ebc_urls[agency_key]["url"]
+            scraper = EBCWebScraper(base_url=base_url, min_date="2020-01-01")
+
+            try:
+                article_urls = scraper.scrape_index_page(base_url)
+            except Exception as e:
+                pytest.skip(f"Failed to fetch {agency_key} index page: {e}")
+
+            # Should find articles with any of the 3 strategies
+            assert len(article_urls) > 0, (
+                f"{agency_key} index page returned 0 URLs. "
+                f"All 3 scraping strategies failed to find articles."
+            )
+
+            # All URLs should be valid
+            for url in article_urls[:5]:  # Check first 5
+                assert url.startswith("https://"), f"Invalid URL format: {url}"
+                assert "ebc.com.br" in url, f"URL should be from EBC domain: {url}"

--- a/tests/integration/test_plone6_integration.py
+++ b/tests/integration/test_plone6_integration.py
@@ -1,0 +1,190 @@
+"""
+Integration tests for Plone6APIScraper against real Plone 6 REST API.
+
+Tests the Plone6APIScraper with real HTTP requests to validate that:
+- The ++api++/@search endpoint is accessible and returns valid JSON
+- Article extraction from JSON works correctly
+- Date filtering is applied properly
+"""
+
+import pytest
+import requests
+from datetime import datetime, timedelta
+from pathlib import Path
+from govbr_scraper.scrapers.plone6_api_scraper import Plone6APIScraper
+from govbr_scraper.scrapers.yaml_config import load_urls_from_yaml
+
+# Choose 1 stable Plone6 agency for testing
+# esporte is a good choice as it's a major government agency with consistent availability
+PLONE6_AGENCY = "esporte"
+
+
+@pytest.fixture(scope="module")
+def plone6_agency_url():
+    """Load Plone6 agency URL from YAML configuration."""
+    config_dir = str(Path(__file__).parent.parent.parent / "src" / "govbr_scraper" / "scrapers" / "config")
+
+    try:
+        urls = load_urls_from_yaml(config_dir, "site_urls.yaml")
+    except Exception as e:
+        pytest.skip(f"Could not load site_urls.yaml: {e}")
+
+    if PLONE6_AGENCY not in urls:
+        pytest.skip(f"{PLONE6_AGENCY} not found in site_urls.yaml")
+
+    agency_data = urls[PLONE6_AGENCY]
+
+    # Verify it's actually a Plone6 API agency
+    if agency_data.get("scraper_type") != "plone6_api":
+        pytest.skip(
+            f"{PLONE6_AGENCY} is not a plone6_api agency "
+            f"(type: {agency_data.get('scraper_type')})"
+        )
+
+    return agency_data["url"]
+
+
+@pytest.mark.integration
+class TestPlone6APIScraper:
+    """Test Plone6APIScraper against real Plone 6 REST API."""
+
+    def test_scrape_news_returns_articles(self, plone6_agency_url):
+        """
+        Plone6APIScraper.scrape_news() should return articles from real API.
+
+        This test validates:
+        - API is accessible and returns data
+        - Articles are extracted correctly from JSON
+        - Required fields (title, url, content, published_at) are present
+        - Date filtering works (min_date constraint)
+        """
+        # Use recent date range to limit results and ensure data exists
+        min_date = (datetime.now() - timedelta(days=30)).strftime("%Y-%m-%d")
+
+        scraper = Plone6APIScraper(
+            base_url=plone6_agency_url,
+            min_date=min_date,
+        )
+
+        try:
+            articles = scraper.scrape_news()
+        except requests.exceptions.RequestException as e:
+            pytest.skip(f"Failed to fetch from API (network issue): {e}")
+        except Exception as e:
+            pytest.fail(f"scrape_news() raised unexpected error: {e}")
+
+        # Should find at least some articles in the last 30 days
+        assert len(articles) > 0, (
+            f"No articles found for {PLONE6_AGENCY} in last 30 days. "
+            f"This may indicate API changes or the agency hasn't published recently."
+        )
+
+        # Validate first article structure
+        first = articles[0]
+
+        # Required fields
+        assert "title" in first, "title field is missing"
+        assert first["title"], "title is empty"
+        assert isinstance(first["title"], str), f"title should be str, got {type(first['title'])}"
+
+        assert "url" in first, "url field is missing"
+        assert first["url"], "url is empty"
+        assert first["url"].startswith("https://"), f"url should be absolute HTTPS, got {first['url']}"
+
+        assert "content" in first, "content field is missing"
+        assert first["content"], "content is empty"
+        assert isinstance(first["content"], str), f"content should be str, got {type(first['content'])}"
+
+        assert "published_at" in first, "published_at field is missing"
+        assert first["published_at"], "published_at is missing"
+        assert isinstance(first["published_at"], datetime), (
+            f"published_at should be datetime, got {type(first['published_at'])}"
+        )
+
+        # Validate date is within expected range
+        # Note: published_at from Plone6 API is timezone-aware, so compare dates only
+        min_date_dt = datetime.strptime(min_date, "%Y-%m-%d").date()
+        assert first["published_at"].date() >= min_date_dt, (
+            f"published_at {first['published_at'].date()} is before min_date {min_date_dt}"
+        )
+
+        # Optional but expected fields
+        assert "agency" in first, "agency field is missing"
+
+    def test_build_api_url_returns_valid_json(self, plone6_agency_url):
+        """
+        _build_api_url() should generate valid Plone 6 REST API URL.
+
+        This test validates:
+        - URL transformation (base URL -> ++api++/@search) works correctly
+        - Generated URL returns valid JSON
+        - JSON has expected Plone API structure (items array)
+        """
+        scraper = Plone6APIScraper(
+            base_url=plone6_agency_url,
+            min_date="2020-01-01",
+        )
+
+        # Build API URL for first page
+        api_url = scraper._build_api_url(b_start=0, b_size=10)
+
+        # Validate URL structure
+        assert "++api++" in api_url, "API URL should contain ++api++ segment"
+        assert "@search" in api_url, "API URL should contain @search endpoint"
+
+        # Test actual HTTP request
+        try:
+            response = requests.get(api_url, timeout=30)
+            response.raise_for_status()
+        except requests.exceptions.RequestException as e:
+            pytest.skip(f"API request failed (network issue): {e}")
+
+        # Should be valid JSON
+        try:
+            data = response.json()
+        except ValueError as e:
+            pytest.fail(f"API response is not valid JSON: {e}")
+
+        # Validate Plone API response structure
+        assert isinstance(data, dict), f"API response should be dict, got {type(data)}"
+        assert "items" in data, "API response should contain 'items' key (Plone REST API format)"
+        assert isinstance(data["items"], list), f"'items' should be a list, got {type(data['items'])}"
+
+        # Should have pagination metadata
+        assert "items_total" in data, "API response should contain 'items_total' (Plone pagination)"
+
+    def test_date_filtering_works(self, plone6_agency_url):
+        """
+        Date filtering (min_date) should be applied correctly.
+
+        This test validates that articles older than min_date are not returned.
+        """
+        # Use a recent cutoff date
+        min_date = (datetime.now() - timedelta(days=7)).strftime("%Y-%m-%d")
+        min_date_dt = datetime.strptime(min_date, "%Y-%m-%d")
+
+        scraper = Plone6APIScraper(
+            base_url=plone6_agency_url,
+            min_date=min_date,
+        )
+
+        try:
+            articles = scraper.scrape_news()
+        except Exception as e:
+            pytest.skip(f"Failed to fetch from API: {e}")
+
+        if not articles:
+            pytest.skip(f"No articles found for {PLONE6_AGENCY} in last 7 days")
+
+        # All articles should be newer than min_date
+        for i, article in enumerate(articles):
+            published_at = article.get("published_at")
+            assert published_at is not None, f"Article {i} has no published_at"
+            assert isinstance(published_at, datetime), (
+                f"Article {i} published_at should be datetime, got {type(published_at)}"
+            )
+
+            # Allow some timezone/boundary flexibility
+            assert published_at.date() >= min_date_dt.date(), (
+                f"Article {i} published_at {published_at} is before min_date {min_date_dt}"
+            )


### PR DESCRIPTION
## Summary

- Remove 3 classes problemáticas (`TestSummaryReport`, `TestComparisonWithWorkingAgency`, `TestExtractionFunctions`) e helper `find_news_items()` com divergência crítica do Fallback 3
- Refatora testes existentes para usar `WebScraper.scrape_page()` com mock de `fetch_page()`, alinhando código de teste com produção
- Adiciona `conftest.py` com skip-count enforcement (>50% skips = falha no CI)
- Cobre as 2 lacunas críticas: `Plone6APIScraper` (`test_plone6_integration.py`) e `EBCWebScraper` (`test_ebc_integration.py`)
- Implementa opt-in explícito de agências: URLs lidas do YAML, mas lista de agências nos testes é declarada explicitamente

Closes #34

## Test plan

- [ ] `poetry run pytest tests/integration/ --collect-only` — deve coletar 25 testes sem erros
- [ ] `poetry run pytest tests/integration/ -v -m integration` — executar contra sites reais e verificar que os 3 protocolos passam (HTML, Plone6 API, EBC)
- [ ] Verificar que desconexão de rede com >50% skips causa falha no CI (skip-count enforcement)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)