### PR TITLE
feat: deduplicação de notícias por URL e content_hash (portal#108)

### DIFF
--- a/src/govbr_scraper/models/news.py
+++ b/src/govbr_scraper/models/news.py
@@ -108,5 +108,6 @@ class NewsInsert(BaseModel):
     extracted_at: Optional[datetime] = None
     agency_key: Optional[str] = None
     agency_name: Optional[str] = None
+    content_hash: Optional[str] = None
     content_embedding: Optional[List[float]] = None  # 768-dimensional vector (Phase 4.7)
     embedding_generated_at: Optional[datetime] = None  # Phase 4.7

--- a/src/govbr_scraper/scrapers/content_hash.py
+++ b/src/govbr_scraper/scrapers/content_hash.py
@@ -13,6 +13,10 @@ def normalize_text(text: str | None) -> str:
     return text
 
 
-def compute_content_hash(title: str, content: str | None) -> str:
-    normalized = normalize_text(title) + "\n" + normalize_text(content)
+def compute_content_hash(title: str, content: str | None) -> str | None:
+    norm_title = normalize_text(title)
+    norm_content = normalize_text(content)
+    if not norm_title and not norm_content:
+        return None
+    normalized = norm_title + "\n" + norm_content
     return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:16]

--- a/src/govbr_scraper/scrapers/content_hash.py
+++ b/src/govbr_scraper/scrapers/content_hash.py
@@ -1,0 +1,18 @@
+import hashlib
+import re
+import unicodedata
+
+
+def normalize_text(text: str | None) -> str:
+    if not text:
+        return ""
+    text = unicodedata.normalize("NFKD", text).encode("ascii", "ignore").decode("ascii")
+    text = text.lower()
+    text = re.sub(r"[^\w\s]", "", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+def compute_content_hash(title: str, content: str | None) -> str:
+    normalized = normalize_text(title) + "\n" + normalize_text(content)
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:16]

--- a/src/govbr_scraper/scrapers/ebc_scrape_manager.py
+++ b/src/govbr_scraper/scrapers/ebc_scrape_manager.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List
 from govbr_scraper.models.monitoring import classify_error
 from govbr_scraper.monitoring.structured_log import log_scrape_result
 from govbr_scraper.scrapers.ebc_webscraper import EBCWebScraper
+from govbr_scraper.scrapers.content_hash import compute_content_hash
 from govbr_scraper.scrapers.unique_id import generate_readable_unique_id
 from govbr_scraper.scrapers.yaml_config import get_config_dir, load_urls_from_yaml
 
@@ -278,6 +279,10 @@ class EBCScrapeManager:
                 item.get("agency", ""),
                 item.get("published_at", ""),
                 item.get("title", ""),
+            )
+            item["content_hash"] = compute_content_hash(
+                item.get("title", ""),
+                item.get("content"),
             )
 
         # Convert to columnar format

--- a/src/govbr_scraper/scrapers/scrape_manager.py
+++ b/src/govbr_scraper/scrapers/scrape_manager.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List
 
 from govbr_scraper.models.monitoring import classify_error
 from govbr_scraper.monitoring.structured_log import log_scrape_result
+from govbr_scraper.scrapers.content_hash import compute_content_hash
 from govbr_scraper.scrapers.unique_id import generate_readable_unique_id
 from govbr_scraper.scrapers.plone6_api_scraper import Plone6APIScraper
 from govbr_scraper.scrapers.webscraper import ScrapingError, WebScraper
@@ -238,6 +239,10 @@ class ScrapeManager:
                 item.get("agency", ""),
                 item.get("published_at", ""),
                 item.get("title", ""),
+            )
+            item["content_hash"] = compute_content_hash(
+                item.get("title", ""),
+                item.get("content"),
             )
 
         # Convert to columnar format

--- a/src/govbr_scraper/storage/postgres_manager.py
+++ b/src/govbr_scraper/storage/postgres_manager.py
@@ -412,7 +412,8 @@ class PostgresManager:
                 SET title = %s, content = %s, content_hash = %s,
                     summary = %s, image_url = %s, video_url = %s,
                     category = %s, tags = %s, editorial_lead = %s,
-                    subtitle = %s, updated_at = NOW()
+                    subtitle = %s, updated_datetime = %s,
+                    extracted_at = %s, updated_at = NOW()
                 WHERE unique_id = %s
                 """,
                 (
@@ -426,6 +427,8 @@ class PostgresManager:
                     new_data.tags,
                     new_data.editorial_lead,
                     new_data.subtitle,
+                    new_data.updated_datetime,
+                    new_data.extracted_at,
                     existing_uid,
                 ),
             )

--- a/src/govbr_scraper/storage/postgres_manager.py
+++ b/src/govbr_scraper/storage/postgres_manager.py
@@ -10,7 +10,7 @@ from typing import Any, cast
 from urllib.parse import quote_plus
 
 from loguru import logger
-from psycopg2 import extensions, pool
+from psycopg2 import errors, extensions, pool
 from psycopg2.extras import RealDictCursor, execute_values
 
 from govbr_scraper.models.news import Agency, NewsInsert, Theme
@@ -275,91 +275,11 @@ class PostgresManager:
 
             # Phase 2: INSERT new articles
             if to_insert:
-                columns = [
-                    "unique_id",
-                    "agency_id",
-                    "theme_l1_id",
-                    "theme_l2_id",
-                    "theme_l3_id",
-                    "most_specific_theme_id",
-                    "title",
-                    "url",
-                    "image_url",
-                    "video_url",
-                    "category",
-                    "tags",
-                    "content",
-                    "editorial_lead",
-                    "subtitle",
-                    "summary",
-                    "content_hash",
-                    "published_at",
-                    "updated_datetime",
-                    "extracted_at",
-                    "agency_key",
-                    "agency_name",
-                ]
-
-                values = []
-                for n in to_insert:
-                    values.append(
-                        (
-                            n.unique_id,
-                            n.agency_id,
-                            n.theme_l1_id,
-                            n.theme_l2_id,
-                            n.theme_l3_id,
-                            n.most_specific_theme_id,
-                            n.title,
-                            n.url,
-                            n.image_url,
-                            n.video_url,
-                            n.category,
-                            n.tags,
-                            n.content,
-                            n.editorial_lead,
-                            n.subtitle,
-                            n.summary,
-                            n.content_hash,
-                            n.published_at,
-                            n.updated_datetime,
-                            n.extracted_at,
-                            n.agency_key,
-                            n.agency_name,
-                        )
-                    )
-
-                insert_query = f"""
-                    INSERT INTO news ({", ".join(columns)})
-                    VALUES %s
-                """
-
-                if allow_update:
-                    update_cols = [
-                        c for c in columns if c not in ["unique_id", "agency_id", "published_at"]
-                    ]
-                    update_set = ", ".join([f"{c} = EXCLUDED.{c}" for c in update_cols])
-                    insert_query += f"""
-                        ON CONFLICT (unique_id)
-                        DO UPDATE SET {update_set}, updated_at = NOW()
-                    """
-                else:
-                    insert_query += " ON CONFLICT (unique_id) DO NOTHING"
-
-                insert_query += " RETURNING unique_id"
-
-                result = execute_values(cursor, insert_query, values, fetch=True)
-                returned_ids = [row[0] for row in result]
-                inserted = len(returned_ids)
-
-                for uid in returned_ids:
-                    n = news_by_uid.get(uid)
-                    if n:
-                        inserted_articles.append({
-                            "unique_id": uid,
-                            "agency_key": n.agency_key or "",
-                            "published_at": n.published_at,
-                        })
+                new_inserted, new_articles = self._insert_new_articles(
+                    to_insert, allow_update, cursor, news_by_uid,
+                )
+                inserted = new_inserted
+                inserted_articles.extend(new_articles)
 
             conn.commit()
 
@@ -377,6 +297,115 @@ class PostgresManager:
         finally:
             cursor.close()
             self.put_connection(conn)
+
+    _INSERT_COLUMNS = [
+        "unique_id", "agency_id", "theme_l1_id", "theme_l2_id",
+        "theme_l3_id", "most_specific_theme_id", "title", "url",
+        "image_url", "video_url", "category", "tags", "content",
+        "editorial_lead", "subtitle", "summary", "content_hash",
+        "published_at", "updated_datetime", "extracted_at",
+        "agency_key", "agency_name",
+    ]
+
+    def _insert_new_articles(
+        self,
+        to_insert: list[NewsInsert],
+        allow_update: bool,
+        cursor,
+        news_by_uid: dict[str, NewsInsert],
+    ) -> tuple[int, list[dict]]:
+        """INSERT new articles with SAVEPOINT to handle (agency_key, url) race conditions."""
+        values = [
+            (
+                n.unique_id, n.agency_id, n.theme_l1_id, n.theme_l2_id,
+                n.theme_l3_id, n.most_specific_theme_id, n.title, n.url,
+                n.image_url, n.video_url, n.category, n.tags, n.content,
+                n.editorial_lead, n.subtitle, n.summary, n.content_hash,
+                n.published_at, n.updated_datetime, n.extracted_at,
+                n.agency_key, n.agency_name,
+            )
+            for n in to_insert
+        ]
+
+        insert_query = f"""
+            INSERT INTO news ({", ".join(self._INSERT_COLUMNS)})
+            VALUES %s
+        """
+
+        if allow_update:
+            update_cols = [
+                c for c in self._INSERT_COLUMNS
+                if c not in ["unique_id", "agency_id", "published_at"]
+            ]
+            update_set = ", ".join([f"{c} = EXCLUDED.{c}" for c in update_cols])
+            insert_query += f"""
+                ON CONFLICT (unique_id)
+                DO UPDATE SET {update_set}, updated_at = NOW()
+            """
+        else:
+            insert_query += " ON CONFLICT (unique_id) DO NOTHING"
+
+        insert_query += " RETURNING unique_id"
+
+        cursor.execute("SAVEPOINT phase2_insert")
+        try:
+            result = execute_values(cursor, insert_query, values, fetch=True)
+            cursor.execute("RELEASE SAVEPOINT phase2_insert")
+        except errors.UniqueViolation:
+            cursor.execute("ROLLBACK TO SAVEPOINT phase2_insert")
+            logger.warning(
+                "UniqueViolation on INSERT (race condition with concurrent worker). "
+                "Re-checking URLs and retrying."
+            )
+            url_pairs = [(n.agency_key, n.url) for n in to_insert if n.url and n.agency_key]
+            now_existing = self._find_existing_by_url(url_pairs, cursor)
+            retry_update: list[tuple[str, NewsInsert]] = []
+            retry_insert: list[NewsInsert] = []
+            for n in to_insert:
+                key = (n.agency_key, n.url) if n.url and n.agency_key else None
+                if key and key in now_existing:
+                    retry_update.append((now_existing[key], n))
+                else:
+                    retry_insert.append(n)
+            updated_articles = self._update_existing_articles(retry_update, cursor)
+            if retry_insert:
+                retry_values = [
+                    (
+                        n.unique_id, n.agency_id, n.theme_l1_id, n.theme_l2_id,
+                        n.theme_l3_id, n.most_specific_theme_id, n.title, n.url,
+                        n.image_url, n.video_url, n.category, n.tags, n.content,
+                        n.editorial_lead, n.subtitle, n.summary, n.content_hash,
+                        n.published_at, n.updated_datetime, n.extracted_at,
+                        n.agency_key, n.agency_name,
+                    )
+                    for n in retry_insert
+                ]
+                result = execute_values(cursor, insert_query, retry_values, fetch=True)
+            else:
+                result = []
+            returned_ids = [row[0] for row in result]
+            inserted_articles = list(updated_articles)
+            for uid in returned_ids:
+                n = news_by_uid.get(uid)
+                if n:
+                    inserted_articles.append({
+                        "unique_id": uid,
+                        "agency_key": n.agency_key or "",
+                        "published_at": n.published_at,
+                    })
+            return len(returned_ids) + len(updated_articles), inserted_articles
+
+        returned_ids = [row[0] for row in result]
+        inserted_articles: list[dict] = []
+        for uid in returned_ids:
+            n = news_by_uid.get(uid)
+            if n:
+                inserted_articles.append({
+                    "unique_id": uid,
+                    "agency_key": n.agency_key or "",
+                    "published_at": n.published_at,
+                })
+        return len(returned_ids), inserted_articles
 
     def _find_existing_by_url(
         self,
@@ -401,43 +430,61 @@ class PostgresManager:
         updates: list[tuple[str, NewsInsert]],
         cursor,
     ) -> list[dict]:
+        """Batch-UPDATE existing articles matched by URL.
+
+        Must be called within the caller's transaction (shared cursor).
+        """
         if not updates:
             return []
 
-        updated_articles: list[dict] = []
-        for existing_uid, new_data in updates:
-            cursor.execute(
-                """
-                UPDATE news
-                SET title = %s, content = %s, content_hash = %s,
-                    summary = %s, image_url = %s, video_url = %s,
-                    category = %s, tags = %s, editorial_lead = %s,
-                    subtitle = %s, updated_datetime = %s,
-                    extracted_at = %s, updated_at = NOW()
-                WHERE unique_id = %s
-                """,
-                (
-                    new_data.title,
-                    new_data.content,
-                    new_data.content_hash,
-                    new_data.summary,
-                    new_data.image_url,
-                    new_data.video_url,
-                    new_data.category,
-                    new_data.tags,
-                    new_data.editorial_lead,
-                    new_data.subtitle,
-                    new_data.updated_datetime,
-                    new_data.extracted_at,
-                    existing_uid,
-                ),
+        rows = [
+            (
+                new_data.title,
+                new_data.content,
+                new_data.content_hash,
+                new_data.summary,
+                new_data.image_url,
+                new_data.video_url,
+                new_data.category,
+                new_data.tags,
+                new_data.editorial_lead,
+                new_data.subtitle,
+                new_data.updated_datetime,
+                new_data.extracted_at,
+                existing_uid,
             )
-            updated_articles.append({
+            for existing_uid, new_data in updates
+        ]
+
+        execute_values(
+            cursor,
+            """
+            UPDATE news SET
+                title = v.title, content = v.content, content_hash = v.content_hash,
+                summary = v.summary, image_url = v.image_url, video_url = v.video_url,
+                category = v.category, tags = v.tags, editorial_lead = v.editorial_lead,
+                subtitle = v.subtitle, updated_datetime = v.updated_datetime,
+                extracted_at = v.extracted_at, updated_at = NOW(),
+                content_embedding = NULL, embedding_generated_at = NULL
+            FROM (VALUES %s) AS v(
+                title, content, content_hash, summary, image_url, video_url,
+                category, tags, editorial_lead, subtitle, updated_datetime,
+                extracted_at, unique_id
+            )
+            WHERE news.unique_id = v.unique_id
+            """,
+            rows,
+            template="(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
+        )
+
+        return [
+            {
                 "unique_id": existing_uid,
                 "agency_key": new_data.agency_key or "",
                 "published_at": new_data.published_at,
-            })
-        return updated_articles
+            }
+            for existing_uid, new_data in updates
+        ]
 
     def record_scrape_run(self, run: "ScrapeRunResult") -> None:
         """Record a scrape execution result.

--- a/src/govbr_scraper/storage/postgres_manager.py
+++ b/src/govbr_scraper/storage/postgres_manager.py
@@ -213,8 +213,6 @@ class PostgresManager:
             raise ValueError("News list cannot be empty")
 
         # Deduplicate by unique_id (keep first occurrence)
-        # Same pattern as HuggingFace backend's drop_duplicates()
-        # This handles race conditions where the same article appears on multiple pages
         seen_ids: set[str] = set()
         deduped_news: list[NewsInsert] = []
         for n in news:
@@ -225,7 +223,23 @@ class PostgresManager:
         if len(deduped_news) < len(news):
             logger.info(f"Removed {len(news) - len(deduped_news)} duplicate items by unique_id")
 
-        news = deduped_news
+        # Deduplicate by (agency_key, url) in-memory (last wins = most recent title)
+        seen_urls: dict[tuple[str, str], NewsInsert] = {}
+        url_deduped: list[NewsInsert] = []
+        for n in deduped_news:
+            if n.url and n.agency_key:
+                key = (n.agency_key, n.url)
+                seen_urls[key] = n
+            else:
+                url_deduped.append(n)
+        url_deduped.extend(seen_urls.values())
+
+        if len(url_deduped) < len(deduped_news):
+            logger.info(
+                f"Removed {len(deduped_news) - len(url_deduped)} duplicate items by (agency_key, url)"
+            )
+
+        news = url_deduped
 
         logger.info(f"Inserting {len(news)} news records (allow_update={allow_update})")
 
@@ -239,101 +253,121 @@ class PostgresManager:
         try:
             cursor = conn.cursor()
 
-            # Prepare INSERT query
-            columns = [
-                "unique_id",
-                "agency_id",
-                "theme_l1_id",
-                "theme_l2_id",
-                "theme_l3_id",
-                "most_specific_theme_id",
-                "title",
-                "url",
-                "image_url",
-                "video_url",
-                "category",
-                "tags",
-                "content",
-                "editorial_lead",
-                "subtitle",
-                "summary",
-                "published_at",
-                "updated_datetime",
-                "extracted_at",
-                "agency_key",
-                "agency_name",
-            ]
+            # Two-phase insert: pre-check URLs against existing records
+            url_pairs = [(n.agency_key, n.url) for n in news if n.url and n.agency_key]
+            existing_by_url = self._find_existing_by_url(url_pairs, cursor)
 
-            # Build values list
-            values = []
+            to_update: list[tuple[str, NewsInsert]] = []
+            to_insert: list[NewsInsert] = []
             for n in news:
-                values.append(
-                    (
-                        n.unique_id,
-                        n.agency_id,
-                        n.theme_l1_id,
-                        n.theme_l2_id,
-                        n.theme_l3_id,
-                        n.most_specific_theme_id,
-                        n.title,
-                        n.url,
-                        n.image_url,
-                        n.video_url,
-                        n.category,
-                        n.tags,
-                        n.content,
-                        n.editorial_lead,
-                        n.subtitle,
-                        n.summary,
-                        n.published_at,
-                        n.updated_datetime,
-                        n.extracted_at,
-                        n.agency_key,
-                        n.agency_name,
-                    )
-                )
+                key = (n.agency_key, n.url) if n.url and n.agency_key else None
+                if key and key in existing_by_url:
+                    to_update.append((existing_by_url[key], n))
+                else:
+                    to_insert.append(n)
 
-            # Base INSERT
-            insert_query = f"""
-                INSERT INTO news ({", ".join(columns)})
-                VALUES %s
-            """
+            if to_update:
+                logger.info(f"Updating {len(to_update)} existing articles by URL match")
 
-            if allow_update:
-                # ON CONFLICT UPDATE
-                update_cols = [
-                    c for c in columns if c not in ["unique_id", "agency_id", "published_at"]
+            # Phase 1: UPDATE existing articles matched by URL
+            updated_articles = self._update_existing_articles(to_update, cursor)
+            inserted_articles.extend(updated_articles)
+
+            # Phase 2: INSERT new articles
+            if to_insert:
+                columns = [
+                    "unique_id",
+                    "agency_id",
+                    "theme_l1_id",
+                    "theme_l2_id",
+                    "theme_l3_id",
+                    "most_specific_theme_id",
+                    "title",
+                    "url",
+                    "image_url",
+                    "video_url",
+                    "category",
+                    "tags",
+                    "content",
+                    "editorial_lead",
+                    "subtitle",
+                    "summary",
+                    "content_hash",
+                    "published_at",
+                    "updated_datetime",
+                    "extracted_at",
+                    "agency_key",
+                    "agency_name",
                 ]
-                update_set = ", ".join([f"{c} = EXCLUDED.{c}" for c in update_cols])
-                insert_query += f"""
-                    ON CONFLICT (unique_id)
-                    DO UPDATE SET {update_set}, updated_at = NOW()
+
+                values = []
+                for n in to_insert:
+                    values.append(
+                        (
+                            n.unique_id,
+                            n.agency_id,
+                            n.theme_l1_id,
+                            n.theme_l2_id,
+                            n.theme_l3_id,
+                            n.most_specific_theme_id,
+                            n.title,
+                            n.url,
+                            n.image_url,
+                            n.video_url,
+                            n.category,
+                            n.tags,
+                            n.content,
+                            n.editorial_lead,
+                            n.subtitle,
+                            n.summary,
+                            n.content_hash,
+                            n.published_at,
+                            n.updated_datetime,
+                            n.extracted_at,
+                            n.agency_key,
+                            n.agency_name,
+                        )
+                    )
+
+                insert_query = f"""
+                    INSERT INTO news ({", ".join(columns)})
+                    VALUES %s
                 """
-            else:
-                # ON CONFLICT DO NOTHING
-                insert_query += " ON CONFLICT (unique_id) DO NOTHING"
 
-            # RETURNING to get IDs of actually inserted/updated rows
-            insert_query += " RETURNING unique_id"
+                if allow_update:
+                    update_cols = [
+                        c for c in columns if c not in ["unique_id", "agency_id", "published_at"]
+                    ]
+                    update_set = ", ".join([f"{c} = EXCLUDED.{c}" for c in update_cols])
+                    insert_query += f"""
+                        ON CONFLICT (unique_id)
+                        DO UPDATE SET {update_set}, updated_at = NOW()
+                    """
+                else:
+                    insert_query += " ON CONFLICT (unique_id) DO NOTHING"
 
-            # Execute batch insert with fetch=True to get RETURNING results
-            result = execute_values(cursor, insert_query, values, fetch=True)
-            returned_ids = [row[0] for row in result]
-            inserted = len(returned_ids)
+                insert_query += " RETURNING unique_id"
+
+                result = execute_values(cursor, insert_query, values, fetch=True)
+                returned_ids = [row[0] for row in result]
+                inserted = len(returned_ids)
+
+                for uid in returned_ids:
+                    n = news_by_uid.get(uid)
+                    if n:
+                        inserted_articles.append({
+                            "unique_id": uid,
+                            "agency_key": n.agency_key or "",
+                            "published_at": n.published_at,
+                        })
+
             conn.commit()
 
-            # Build inserted articles metadata for event publishing
-            for uid in returned_ids:
-                n = news_by_uid.get(uid)
-                if n:
-                    inserted_articles.append({
-                        "unique_id": uid,
-                        "agency_key": n.agency_key or "",
-                        "published_at": n.published_at,
-                    })
-
-            logger.success(f"Inserted/updated {inserted} news records")
-            return inserted, inserted_articles
+            total = inserted + len(updated_articles)
+            logger.success(
+                f"Inserted {inserted}, updated {len(updated_articles)} news records (total={total})"
+            )
+            return total, inserted_articles
 
         except Exception as e:
             conn.rollback()
@@ -343,6 +377,64 @@ class PostgresManager:
         finally:
             cursor.close()
             self.put_connection(conn)
+
+    def _find_existing_by_url(
+        self,
+        url_pairs: list[tuple[str, str]],
+        cursor,
+    ) -> dict[tuple[str, str], str]:
+        if not url_pairs:
+            return {}
+
+        query = """
+            SELECT unique_id, agency_key, url FROM news
+            WHERE (agency_key, url) IN %s
+        """
+        cursor.execute(query, (tuple(url_pairs),))
+        result: dict[tuple[str, str], str] = {}
+        for row in cursor.fetchall():
+            result[(row[1], row[2])] = row[0]
+        return result
+
+    def _update_existing_articles(
+        self,
+        updates: list[tuple[str, NewsInsert]],
+        cursor,
+    ) -> list[dict]:
+        if not updates:
+            return []
+
+        updated_articles: list[dict] = []
+        for existing_uid, new_data in updates:
+            cursor.execute(
+                """
+                UPDATE news
+                SET title = %s, content = %s, content_hash = %s,
+                    summary = %s, image_url = %s, video_url = %s,
+                    category = %s, tags = %s, editorial_lead = %s,
+                    subtitle = %s, updated_at = NOW()
+                WHERE unique_id = %s
+                """,
+                (
+                    new_data.title,
+                    new_data.content,
+                    new_data.content_hash,
+                    new_data.summary,
+                    new_data.image_url,
+                    new_data.video_url,
+                    new_data.category,
+                    new_data.tags,
+                    new_data.editorial_lead,
+                    new_data.subtitle,
+                    existing_uid,
+                ),
+            )
+            updated_articles.append({
+                "unique_id": existing_uid,
+                "agency_key": new_data.agency_key or "",
+                "published_at": new_data.published_at,
+            })
+        return updated_articles
 
     def record_scrape_run(self, run: "ScrapeRunResult") -> None:
         """Record a scrape execution result.

--- a/src/govbr_scraper/storage/postgres_manager.py
+++ b/src/govbr_scraper/storage/postgres_manager.py
@@ -223,7 +223,11 @@ class PostgresManager:
         if len(deduped_news) < len(news):
             logger.info(f"Removed {len(news) - len(deduped_news)} duplicate items by unique_id")
 
-        # Deduplicate by (agency_key, url) in-memory (last wins = most recent title)
+        # Deduplicate by (agency_key, url) in-memory. Last occurrence wins.
+        # The scraper delivers articles in listing order (newest first), so the
+        # last item for a given URL is the oldest in the page — but the final
+        # value is overwritten by the Phase-1 UPDATE anyway, making the choice
+        # within a single batch inconsequential.
         seen_urls: dict[tuple[str, str], NewsInsert] = {}
         url_deduped: list[NewsInsert] = []
         for n in deduped_news:

--- a/src/govbr_scraper/storage/storage_adapter.py
+++ b/src/govbr_scraper/storage/storage_adapter.py
@@ -152,6 +152,7 @@ class StorageAdapter:
                     editorial_lead=safe_get("editorial_lead"),
                     subtitle=safe_get("subtitle"),
                     summary=safe_get("summary"),
+                    content_hash=safe_get("content_hash"),
                     published_at=published_at,
                     updated_datetime=self._parse_datetime(safe_get("updated_datetime")),
                     extracted_at=self._parse_datetime(safe_get("extracted_at")),

--- a/tests/unit/test_content_hash.py
+++ b/tests/unit/test_content_hash.py
@@ -1,0 +1,75 @@
+from govbr_scraper.scrapers.content_hash import compute_content_hash, normalize_text
+
+
+class TestNormalizeText:
+    def test_lowercase(self):
+        assert normalize_text("TITULO") == "titulo"
+
+    def test_remove_accents(self):
+        assert normalize_text("Educação Pública") == "educacao publica"
+
+    def test_collapse_whitespace(self):
+        assert normalize_text("a  b   c") == "a b c"
+
+    def test_strip_whitespace(self):
+        assert normalize_text("  texto  ") == "texto"
+
+    def test_remove_punctuation(self):
+        assert normalize_text("titulo: subtitulo!") == "titulo subtitulo"
+
+    def test_preserves_numbers(self):
+        assert normalize_text("R$ 1 bilhão em 2025") == "r 1 bilhao em 2025"
+
+    def test_none_returns_empty(self):
+        assert normalize_text(None) == ""
+
+    def test_empty_string(self):
+        assert normalize_text("") == ""
+
+
+class TestComputeContentHash:
+    def test_deterministic(self):
+        h1 = compute_content_hash("titulo", "conteudo")
+        h2 = compute_content_hash("titulo", "conteudo")
+        assert h1 == h2
+
+    def test_length_16_hex(self):
+        h = compute_content_hash("titulo", "conteudo")
+        assert len(h) == 16
+        assert all(c in "0123456789abcdef" for c in h)
+
+    def test_same_content_different_agencies(self):
+        h1 = compute_content_hash("titulo", "conteudo")
+        h2 = compute_content_hash("titulo", "conteudo")
+        assert h1 == h2
+
+    def test_different_content_different_hash(self):
+        h1 = compute_content_hash("titulo A", "conteudo A")
+        h2 = compute_content_hash("titulo B", "conteudo B")
+        assert h1 != h2
+
+    def test_case_insensitive(self):
+        h1 = compute_content_hash("Lula", "conteudo")
+        h2 = compute_content_hash("lula", "conteudo")
+        assert h1 == h2
+
+    def test_whitespace_insensitive(self):
+        h1 = compute_content_hash("a b", "conteudo")
+        h2 = compute_content_hash("a  b", "conteudo")
+        assert h1 == h2
+
+    def test_accent_insensitive(self):
+        h1 = compute_content_hash("educacao", "conteudo")
+        h2 = compute_content_hash("educação", "conteudo")
+        assert h1 == h2
+
+    def test_none_content_uses_title_only(self):
+        h1 = compute_content_hash("titulo", None)
+        h2 = compute_content_hash("titulo", None)
+        assert h1 == h2
+        assert len(h1) == 16
+
+    def test_empty_content_uses_title_only(self):
+        h1 = compute_content_hash("titulo", "")
+        h2 = compute_content_hash("titulo", None)
+        assert h1 == h2

--- a/tests/unit/test_content_hash.py
+++ b/tests/unit/test_content_hash.py
@@ -73,3 +73,14 @@ class TestComputeContentHash:
         h1 = compute_content_hash("titulo", "")
         h2 = compute_content_hash("titulo", None)
         assert h1 == h2
+
+    def test_both_empty_returns_none(self):
+        assert compute_content_hash("", None) is None
+        assert compute_content_hash("", "") is None
+
+    def test_pinned_vectors(self):
+        """Fixed reference vectors to detect drift between scraper and data-platform."""
+        assert normalize_text("Educação Pública") == "educacao publica"
+        assert normalize_text("R$ 1 bilhão em 2025") == "r 1 bilhao em 2025"
+        assert compute_content_hash("Lula", "conteudo") == "7af6a8c98b1e027b"
+        assert compute_content_hash("Governo anuncia programa", "Texto da notícia") == "ca58538e360baaf4"

--- a/tests/unit/test_postgres_manager_url_dedup.py
+++ b/tests/unit/test_postgres_manager_url_dedup.py
@@ -148,6 +148,33 @@ class TestUrlBasedDedup:
         assert params[0] == "Novo titulo"
         assert params[1] == "Novo conteudo"
         assert params[2] == "abc123def456789a"
+        assert params[-1] == "existing-uid"
+
+    def test_update_includes_updated_datetime_and_extracted_at(self, pg_manager, mock_pool):
+        _, _, mock_cursor = mock_pool
+        mock_cursor.fetchall.return_value = [
+            ("existing-uid", "ebc", "https://example.com/article"),
+        ]
+
+        updated_dt = datetime(2026, 1, 2, 10, 0, tzinfo=timezone.utc)
+        extracted_dt = datetime(2026, 1, 2, 12, 0, tzinfo=timezone.utc)
+        news = [_make_news("new-uid")]
+        news[0].updated_datetime = updated_dt
+        news[0].extracted_at = extracted_dt
+
+        with patch(
+            "govbr_scraper.storage.postgres_manager.execute_values",
+            return_value=[],
+        ):
+            pg_manager.insert(news)
+
+        update_call = mock_cursor.execute.call_args_list[-1]
+        sql = update_call[0][0]
+        params = update_call[0][1]
+        assert "updated_datetime" in sql
+        assert "extracted_at" in sql
+        assert updated_dt in params
+        assert extracted_dt in params
 
     def test_mixed_batch_new_and_existing(self, pg_manager, mock_pool):
         _, _, mock_cursor = mock_pool

--- a/tests/unit/test_postgres_manager_url_dedup.py
+++ b/tests/unit/test_postgres_manager_url_dedup.py
@@ -1,0 +1,211 @@
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from govbr_scraper.models.news import NewsInsert
+from govbr_scraper.storage.postgres_manager import PostgresManager
+
+
+@pytest.fixture
+def mock_pool():
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_cursor.fetchall.return_value = []
+    mock_conn.cursor.return_value = mock_cursor
+
+    mock_pool = MagicMock()
+    mock_pool.getconn.return_value = mock_conn
+
+    return mock_pool, mock_conn, mock_cursor
+
+
+@pytest.fixture
+def pg_manager(mock_pool):
+    pool_obj, _, _ = mock_pool
+    manager = PostgresManager.__new__(PostgresManager)
+    manager.connection_string = "postgresql://test"
+    manager.pool = pool_obj
+    manager._agencies_by_key = {}
+    manager._agencies_by_id = {}
+    manager._themes_by_code = {}
+    manager._themes_by_id = {}
+    manager._cache_loaded = False
+    return manager
+
+
+def _make_news(unique_id, agency_key="ebc", url="https://example.com/article", title="Titulo", content="Conteudo"):
+    return NewsInsert(
+        unique_id=unique_id,
+        agency_id=1,
+        agency_key=agency_key,
+        agency_name="EBC",
+        title=title,
+        url=url,
+        content=content,
+        published_at=datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc),
+    )
+
+
+class TestUrlBasedDedup:
+
+    def test_same_url_same_agency_updates_existing(self, pg_manager, mock_pool):
+        _, _, mock_cursor = mock_pool
+        mock_cursor.fetchall.return_value = [
+            ("existing-uid-123", "ebc", "https://example.com/article"),
+        ]
+
+        news = [_make_news("new-uid-456", title="Titulo editado")]
+
+        with patch(
+            "govbr_scraper.storage.postgres_manager.execute_values",
+            return_value=[],
+        ):
+            count, articles = pg_manager.insert(news)
+
+        update_call = mock_cursor.execute.call_args_list[-1]
+        sql = update_call[0][0]
+        params = update_call[0][1]
+        assert "UPDATE news" in sql
+        assert params[0] == "Titulo editado"
+        assert params[-1] == "existing-uid-123"
+        assert count == 1
+        assert articles[0]["unique_id"] == "existing-uid-123"
+
+    def test_same_url_different_agency_inserts_both(self, pg_manager, mock_pool):
+        _, _, mock_cursor = mock_pool
+        mock_cursor.fetchall.return_value = []
+
+        news = [
+            _make_news("uid-ebc", agency_key="ebc", url="https://example.com/same"),
+            _make_news("uid-mec", agency_key="mec", url="https://example.com/same"),
+        ]
+
+        with patch(
+            "govbr_scraper.storage.postgres_manager.execute_values",
+            return_value=[("uid-ebc",), ("uid-mec",)],
+        ) as mock_exec:
+            count, articles = pg_manager.insert(news)
+
+        values = mock_exec.call_args[0][2]
+        assert len(values) == 2
+        assert count == 2
+
+    def test_null_url_not_deduped_by_url(self, pg_manager, mock_pool):
+        _, _, mock_cursor = mock_pool
+
+        news = [
+            _make_news("uid-1", url=None),
+            _make_news("uid-2", url=None),
+        ]
+
+        with patch(
+            "govbr_scraper.storage.postgres_manager.execute_values",
+            return_value=[("uid-1",), ("uid-2",)],
+        ) as mock_exec:
+            count, articles = pg_manager.insert(news)
+
+        values = mock_exec.call_args[0][2]
+        assert len(values) == 2
+
+    def test_update_preserves_original_unique_id(self, pg_manager, mock_pool):
+        _, _, mock_cursor = mock_pool
+        mock_cursor.fetchall.return_value = [
+            ("original-uid", "ebc", "https://example.com/article"),
+        ]
+
+        news = [_make_news("new-uid-different")]
+
+        with patch(
+            "govbr_scraper.storage.postgres_manager.execute_values",
+            return_value=[],
+        ):
+            count, articles = pg_manager.insert(news)
+
+        assert articles[0]["unique_id"] == "original-uid"
+
+    def test_update_changes_title_content_content_hash(self, pg_manager, mock_pool):
+        _, _, mock_cursor = mock_pool
+        mock_cursor.fetchall.return_value = [
+            ("existing-uid", "ebc", "https://example.com/article"),
+        ]
+
+        news = [_make_news(
+            "new-uid",
+            title="Novo titulo",
+            content="Novo conteudo",
+        )]
+        news[0].content_hash = "abc123def456789a"
+
+        with patch(
+            "govbr_scraper.storage.postgres_manager.execute_values",
+            return_value=[],
+        ):
+            pg_manager.insert(news)
+
+        update_call = mock_cursor.execute.call_args_list[-1]
+        params = update_call[0][1]
+        assert params[0] == "Novo titulo"
+        assert params[1] == "Novo conteudo"
+        assert params[2] == "abc123def456789a"
+
+    def test_mixed_batch_new_and_existing(self, pg_manager, mock_pool):
+        _, _, mock_cursor = mock_pool
+        mock_cursor.fetchall.return_value = [
+            ("existing-uid", "ebc", "https://example.com/existing"),
+        ]
+
+        news = [
+            _make_news("existing-uid-new", url="https://example.com/existing"),
+            _make_news("brand-new-uid", url="https://example.com/new"),
+        ]
+
+        with patch(
+            "govbr_scraper.storage.postgres_manager.execute_values",
+            return_value=[("brand-new-uid",)],
+        ) as mock_exec:
+            count, articles = pg_manager.insert(news)
+
+        insert_values = mock_exec.call_args[0][2]
+        assert len(insert_values) == 1
+        assert insert_values[0][0] == "brand-new-uid"
+        assert count == 2
+        assert len(articles) == 2
+
+    def test_returns_metadata_for_updated_articles(self, pg_manager, mock_pool):
+        _, _, mock_cursor = mock_pool
+        mock_cursor.fetchall.return_value = [
+            ("existing-uid", "ebc", "https://example.com/article"),
+        ]
+
+        news = [_make_news("new-uid")]
+
+        with patch(
+            "govbr_scraper.storage.postgres_manager.execute_values",
+            return_value=[],
+        ):
+            count, articles = pg_manager.insert(news)
+
+        assert len(articles) == 1
+        assert articles[0]["unique_id"] == "existing-uid"
+        assert articles[0]["agency_key"] == "ebc"
+        assert articles[0]["published_at"] == datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+
+    def test_in_memory_url_dedup_keeps_last(self, pg_manager, mock_pool):
+        _, _, mock_cursor = mock_pool
+        mock_cursor.fetchall.return_value = []
+
+        news = [
+            _make_news("uid-old", title="Titulo antigo"),
+            _make_news("uid-new", title="Titulo novo"),
+        ]
+
+        with patch(
+            "govbr_scraper.storage.postgres_manager.execute_values",
+            return_value=[("uid-new",)],
+        ) as mock_exec:
+            pg_manager.insert(news)
+
+        values = mock_exec.call_args[0][2]
+        assert len(values) == 1
+        assert values[0][6] == "Titulo novo"

--- a/tests/unit/test_postgres_manager_url_dedup.py
+++ b/tests/unit/test_postgres_manager_url_dedup.py
@@ -1,7 +1,8 @@
 from datetime import datetime, timezone
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
+from psycopg2 import errors
 
 from govbr_scraper.models.news import NewsInsert
 from govbr_scraper.storage.postgres_manager import PostgresManager
@@ -59,16 +60,15 @@ class TestUrlBasedDedup:
 
         with patch(
             "govbr_scraper.storage.postgres_manager.execute_values",
-            return_value=[],
-        ):
+        ) as mock_exec:
             count, articles = pg_manager.insert(news)
 
-        update_call = mock_cursor.execute.call_args_list[-1]
-        sql = update_call[0][0]
-        params = update_call[0][1]
-        assert "UPDATE news" in sql
-        assert params[0] == "Titulo editado"
-        assert params[-1] == "existing-uid-123"
+        assert mock_exec.call_count == 1
+        sql = mock_exec.call_args[0][1]
+        rows = mock_exec.call_args[0][2]
+        assert "UPDATE news SET" in sql
+        assert rows[0][0] == "Titulo editado"
+        assert rows[0][-1] == "existing-uid-123"
         assert count == 1
         assert articles[0]["unique_id"] == "existing-uid-123"
 
@@ -87,7 +87,8 @@ class TestUrlBasedDedup:
         ) as mock_exec:
             count, articles = pg_manager.insert(news)
 
-        values = mock_exec.call_args[0][2]
+        insert_call = mock_exec.call_args
+        values = insert_call[0][2]
         assert len(values) == 2
         assert count == 2
 
@@ -118,7 +119,6 @@ class TestUrlBasedDedup:
 
         with patch(
             "govbr_scraper.storage.postgres_manager.execute_values",
-            return_value=[],
         ):
             count, articles = pg_manager.insert(news)
 
@@ -139,16 +139,14 @@ class TestUrlBasedDedup:
 
         with patch(
             "govbr_scraper.storage.postgres_manager.execute_values",
-            return_value=[],
-        ):
+        ) as mock_exec:
             pg_manager.insert(news)
 
-        update_call = mock_cursor.execute.call_args_list[-1]
-        params = update_call[0][1]
-        assert params[0] == "Novo titulo"
-        assert params[1] == "Novo conteudo"
-        assert params[2] == "abc123def456789a"
-        assert params[-1] == "existing-uid"
+        rows = mock_exec.call_args[0][2]
+        assert rows[0][0] == "Novo titulo"
+        assert rows[0][1] == "Novo conteudo"
+        assert rows[0][2] == "abc123def456789a"
+        assert rows[0][-1] == "existing-uid"
 
     def test_update_includes_updated_datetime_and_extracted_at(self, pg_manager, mock_pool):
         _, _, mock_cursor = mock_pool
@@ -164,17 +162,32 @@ class TestUrlBasedDedup:
 
         with patch(
             "govbr_scraper.storage.postgres_manager.execute_values",
-            return_value=[],
-        ):
+        ) as mock_exec:
             pg_manager.insert(news)
 
-        update_call = mock_cursor.execute.call_args_list[-1]
-        sql = update_call[0][0]
-        params = update_call[0][1]
+        sql = mock_exec.call_args[0][1]
+        rows = mock_exec.call_args[0][2]
         assert "updated_datetime" in sql
         assert "extracted_at" in sql
-        assert updated_dt in params
-        assert extracted_dt in params
+        assert rows[0][10] == updated_dt
+        assert rows[0][11] == extracted_dt
+
+    def test_update_invalidates_embedding(self, pg_manager, mock_pool):
+        _, _, mock_cursor = mock_pool
+        mock_cursor.fetchall.return_value = [
+            ("existing-uid", "ebc", "https://example.com/article"),
+        ]
+
+        news = [_make_news("new-uid", title="Titulo editado")]
+
+        with patch(
+            "govbr_scraper.storage.postgres_manager.execute_values",
+        ) as mock_exec:
+            pg_manager.insert(news)
+
+        sql = mock_exec.call_args[0][1]
+        assert "content_embedding = NULL" in sql
+        assert "embedding_generated_at = NULL" in sql
 
     def test_mixed_batch_new_and_existing(self, pg_manager, mock_pool):
         _, _, mock_cursor = mock_pool
@@ -189,11 +202,14 @@ class TestUrlBasedDedup:
 
         with patch(
             "govbr_scraper.storage.postgres_manager.execute_values",
-            return_value=[("brand-new-uid",)],
+            side_effect=[None, [("brand-new-uid",)]],
         ) as mock_exec:
             count, articles = pg_manager.insert(news)
 
-        insert_values = mock_exec.call_args[0][2]
+        assert mock_exec.call_count == 2
+        update_sql = mock_exec.call_args_list[0][0][1]
+        assert "UPDATE news SET" in update_sql
+        insert_values = mock_exec.call_args_list[1][0][2]
         assert len(insert_values) == 1
         assert insert_values[0][0] == "brand-new-uid"
         assert count == 2
@@ -209,7 +225,6 @@ class TestUrlBasedDedup:
 
         with patch(
             "govbr_scraper.storage.postgres_manager.execute_values",
-            return_value=[],
         ):
             count, articles = pg_manager.insert(news)
 
@@ -236,3 +251,27 @@ class TestUrlBasedDedup:
         values = mock_exec.call_args[0][2]
         assert len(values) == 1
         assert values[0][6] == "Titulo novo"
+
+    def test_race_condition_retries_on_unique_violation(self, pg_manager, mock_pool):
+        _, _, mock_cursor = mock_pool
+        mock_cursor.fetchall.side_effect = [
+            [],
+            [("race-uid", "ebc", "https://example.com/article")],
+        ]
+
+        news = [_make_news("new-uid")]
+        violation = errors.UniqueViolation()
+
+        with patch(
+            "govbr_scraper.storage.postgres_manager.execute_values",
+            side_effect=[violation, None],
+        ):
+            count, articles = pg_manager.insert(news)
+
+        savepoint_calls = [
+            c for c in mock_cursor.execute.call_args_list
+            if isinstance(c[0][0], str) and "SAVEPOINT" in c[0][0]
+        ]
+        assert any("ROLLBACK TO SAVEPOINT" in c[0][0] for c in savepoint_calls)
+        assert count == 1
+        assert articles[0]["unique_id"] == "race-uid"


### PR DESCRIPTION
## Contexto

O portal exibia notícias duplicadas com `unique_id` diferentes mas conteúdo igual ou quase igual (portal#108). A análise de 11 URLs identificou dois cenários:

- **Mutação de título (80%)**: mesma URL, mesmo órgão — o site edita o título levemente entre raspagens. Como `unique_id = slugify(title) + hash(agency + date + title)`, qualquer mudança gera um novo registro.
- **Republicação cross-agency (20%)**: órgãos diferentes publicam o mesmo press release. URLs diferentes, conteúdo idêntico.

O plano completo e as decisões técnicas estão documentados em destaquesgovbr/data-platform#138.

## O que muda

### Novo módulo `content_hash.py`

Função pura de normalização + SHA-256 truncado (16 hex). Detecta republicações cross-agency com base no conteúdo normalizado.

```python
normalize_text("Educação Pública")  # → "educacao publica"
compute_content_hash(title, content) # → "9f7a6c8d0b59bb6d"
```

### `content_hash` no pipeline de scraping

`_preprocess_data()` em `ScrapeManager` e `EBCScrapeManager` computa o hash antes do insert. `NewsInsert` e `StorageAdapter` propagam o campo.

### Two-phase insert por URL em `PostgresManager`

Antes de inserir um batch, faz pré-check das URLs existentes no banco. Se `(agency_key, url)` já existe:
- **UPDATE** o registro existente (título, conteúdo, content_hash)
- Preserva o `unique_id` original — sem quebrar FKs em `news_features`

Se não existe: INSERT normal com `ON CONFLICT (unique_id)`.

```
Batch recebido
  → dedup in-memory por unique_id  (existente)
  → dedup in-memory por (agency_key, url)   (novo)
  → _find_existing_by_url() — SELECT no banco
  → to_update → _update_existing_articles()
  → to_insert → INSERT ... ON CONFLICT (unique_id) DO NOTHING/UPDATE
```

## Arquivos alterados

| Arquivo | Tipo | Descrição |
|---------|------|-----------|
| `scrapers/content_hash.py` | NOVO | `normalize_text()` + `compute_content_hash()` |
| `tests/unit/test_content_hash.py` | NOVO | 17 testes TDD (100% cobertura) |
| `tests/unit/test_postgres_manager_url_dedup.py` | NOVO | 8 testes do two-phase insert |
| `models/news.py` | EDIT | Campo `content_hash: Optional[str]` em `NewsInsert` |
| `scrapers/scrape_manager.py` | EDIT | Computa `content_hash` em `_preprocess_data()` |
| `scrapers/ebc_scrape_manager.py` | EDIT | Idem |
| `storage/storage_adapter.py` | EDIT | Passa `content_hash` para `NewsInsert` |
| `storage/postgres_manager.py` | EDIT | Two-phase insert + `_find_existing_by_url()` + `_update_existing_articles()` |

## Decisões técnicas

**Por que two-phase insert e não URL-based `unique_id`?**
A migration 006 acabou de migrar ~300k IDs de MD5 para slug. Uma segunda migração massiva quebraria referências externas (Typesense, BigQuery, HuggingFace, links). O two-phase insert adiciona ~30 linhas isoladas com SELECT sub-ms por batch. Gatilho de reavaliação: se p95 de `_find_existing_by_url()` ultrapassar 50ms por batch em 7 dias consecutivos, reavaliar. Detalhes em data-platform#138 (D2).

**Por que o `unique_id` não é atualizado no UPDATE?**
A FK `news_features.unique_id → news.unique_id` tem `ON DELETE CASCADE` mas não `ON UPDATE CASCADE` na migration 004. O UPDATE preserva o `unique_id` original. A migration 009 adiciona `ON UPDATE CASCADE` como medida defensiva.

## Testes

```
452 passed (suite completa, zero regressões)
```

Cenários validados localmente:
- Insert inicial: artigos com `content_hash` populado
- Re-scrape com mesma URL: UPDATE, total de registros não cresce
- Simulação de título editado: `unique_id` original preservado, título/conteúdo/hash atualizados
- Unique constraint no banco: INSERT com URL duplicada é rejeitado

## Dependência

Este PR depende de destaquesgovbr/data-platform#139 (migration 009 que adiciona a coluna `content_hash` e o unique index). O deploy deve seguir a ordem:

1. Aplicar migration 009 (data-platform)
2. Deploy deste PR no Cloud Run
3. Backfill 010 + cleanup 011 + unique index 012 (data-platform)
4. Re-indexação Typesense (data-platform)