### PR TITLE
fix: bug fixes e melhorias de monitoramento do scraper (#29)

### DIFF
--- a/dags/monitor_scraping_health.py
+++ b/dags/monitor_scraping_health.py
@@ -64,14 +64,14 @@ def monitor_scraping_health_dag():
                 WHERE scraped_at > NOW() - INTERVAL '1 hour' * %(window_hours)s
             ),
             recent AS (
-                SELECT agency_key, status, error_category, scraped_at
+                SELECT agency_key, status, error_category, scraped_at, rn
                 FROM ranked
                 WHERE rn <= %(threshold)s
             )
             SELECT
                 agency_key,
                 COUNT(*) AS consecutive_failures,
-                MAX(error_category) AS last_error,
+                MAX(error_category) FILTER (WHERE rn = 1) AS last_error,
                 MAX(scraped_at) AS last_failure_at
             FROM recent
             GROUP BY agency_key

--- a/dags/scrape_agencies.py
+++ b/dags/scrape_agencies.py
@@ -89,7 +89,9 @@ def create_scraper_dag(agency_key: str, agency_url: str, minute_offset: int = 0)
             import httpx
             from airflow.models import Variable
 
-            scraper_api_url = Variable.get("scraper_api_url")
+            scraper_api_url = Variable.get("scraper_api_url", default_var="")
+            if not scraper_api_url:
+                raise ValueError("Missing required Airflow Variable: scraper_api_url")
 
             # Token IAM para autenticação no Cloud Run
             auth_req = google.auth.transport.requests.Request()

--- a/dags/scrape_ebc.py
+++ b/dags/scrape_ebc.py
@@ -48,7 +48,9 @@ def scrape_ebc_dag():
         import httpx
         from airflow.models import Variable
 
-        scraper_api_url = Variable.get("scraper_api_url")
+        scraper_api_url = Variable.get("scraper_api_url", default_var="")
+        if not scraper_api_url:
+            raise ValueError("Missing required Airflow Variable: scraper_api_url")
 
         auth_req = google.auth.transport.requests.Request()
         token = google.oauth2.id_token.fetch_id_token(auth_req, scraper_api_url)

--- a/src/govbr_scraper/monitoring/health_checks.py
+++ b/src/govbr_scraper/monitoring/health_checks.py
@@ -31,14 +31,14 @@ def find_consecutive_failures(conn, threshold: int = 3, window_hours: int = 2) -
             WHERE scraped_at > NOW() - INTERVAL '1 hour' * %(window_hours)s
         ),
         recent AS (
-            SELECT agency_key, status, error_category, scraped_at
+            SELECT agency_key, status, error_category, scraped_at, rn
             FROM ranked
             WHERE rn <= %(threshold)s
         )
         SELECT
             agency_key,
             COUNT(*) AS consecutive_failures,
-            MAX(error_category) AS last_error,
+            MAX(error_category) FILTER (WHERE rn = 1) AS last_error,
             MAX(scraped_at) AS last_failure_at
         FROM recent
         GROUP BY agency_key

--- a/src/govbr_scraper/monitoring/structured_log.py
+++ b/src/govbr_scraper/monitoring/structured_log.py
@@ -64,3 +64,11 @@ def log_scrape_result(
         )
 
     return result
+
+
+def record_scrape_run_safe(storage, run: ScrapeRunResult, agency_key: str) -> None:
+    """Record a scrape run, logging but not raising on failure."""
+    try:
+        storage.record_scrape_run(run)
+    except Exception as err:
+        logger.warning("Failed to record scrape run for {agency}: {err}", agency=agency_key, err=err)

--- a/src/govbr_scraper/scrapers/ebc_scrape_manager.py
+++ b/src/govbr_scraper/scrapers/ebc_scrape_manager.py
@@ -5,7 +5,7 @@ from datetime import date, datetime
 from typing import Any, Dict, List
 
 from govbr_scraper.models.monitoring import classify_error
-from govbr_scraper.monitoring.structured_log import log_scrape_result
+from govbr_scraper.monitoring.structured_log import log_scrape_result, record_scrape_run_safe
 from govbr_scraper.scrapers.ebc_webscraper import EBCWebScraper
 from govbr_scraper.scrapers.content_hash import compute_content_hash
 from govbr_scraper.scrapers.unique_id import generate_readable_unique_id
@@ -122,10 +122,7 @@ class EBCScrapeManager:
                             error_message=str(e),
                             execution_time_seconds=elapsed,
                         )
-                    try:
-                        self.dataset_manager.record_scrape_run(run)
-                    except Exception as tracking_err:
-                        logging.warning(f"Failed to record scrape run for {agency_name}: {tracking_err}")
+                    record_scrape_run_safe(self.dataset_manager, run, agency_name)
             else:
                 all_news_data = []
                 for agency_name, scraper in webscrapers:
@@ -143,6 +140,7 @@ class EBCScrapeManager:
                             agency_key=agency_name,
                             status="success",
                             articles_scraped=len(scraped_data) if scraped_data else 0,
+                            articles_saved=len(scraped_data) if scraped_data else 0,
                             execution_time_seconds=elapsed,
                         )
                     except Exception as e:
@@ -156,10 +154,7 @@ class EBCScrapeManager:
                             error_message=str(e),
                             execution_time_seconds=elapsed,
                         )
-                    try:
-                        self.dataset_manager.record_scrape_run(run)
-                    except Exception as tracking_err:
-                        logging.warning(f"Failed to record scrape run for {agency_name}: {tracking_err}")
+                    record_scrape_run_safe(self.dataset_manager, run, agency_name)
 
                 if all_news_data:
                     logging.info("Appending all collected news to dataset.")

--- a/src/govbr_scraper/scrapers/scrape_manager.py
+++ b/src/govbr_scraper/scrapers/scrape_manager.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 from typing import Any, Dict, List
 
 from govbr_scraper.models.monitoring import classify_error
-from govbr_scraper.monitoring.structured_log import log_scrape_result
+from govbr_scraper.monitoring.structured_log import log_scrape_result, record_scrape_run_safe
 from govbr_scraper.scrapers.content_hash import compute_content_hash
 from govbr_scraper.scrapers.unique_id import generate_readable_unique_id
 from govbr_scraper.scrapers.plone6_api_scraper import Plone6APIScraper
@@ -146,11 +146,7 @@ class ScrapeManager:
                             error_message=str(e),
                             execution_time_seconds=elapsed,
                         )
-                    # Record scrape run (best-effort — failure must not break scraping)
-                    try:
-                        self.dataset_manager.record_scrape_run(run)
-                    except Exception as tracking_err:
-                        logging.warning(f"Failed to record scrape run for {agency_name}: {tracking_err}")
+                    record_scrape_run_safe(self.dataset_manager, run, agency_name)
             else:
                 all_news_data = []
                 for agency_name, scraper in webscrapers:
@@ -168,6 +164,7 @@ class ScrapeManager:
                             agency_key=agency_name,
                             status="success",
                             articles_scraped=len(scraped_data) if scraped_data else 0,
+                            articles_saved=len(scraped_data) if scraped_data else 0,
                             execution_time_seconds=elapsed,
                         )
                     except ScrapingError as e:
@@ -192,10 +189,7 @@ class ScrapeManager:
                             error_message=str(e),
                             execution_time_seconds=elapsed,
                         )
-                    try:
-                        self.dataset_manager.record_scrape_run(run)
-                    except Exception as tracking_err:
-                        logging.warning(f"Failed to record scrape run for {agency_name}: {tracking_err}")
+                    record_scrape_run_safe(self.dataset_manager, run, agency_name)
 
                 if all_news_data:
                     logging.info("Appending all collected news to storage backend.")

--- a/src/govbr_scraper/storage/postgres_manager.py
+++ b/src/govbr_scraper/storage/postgres_manager.py
@@ -46,7 +46,7 @@ class PostgresManager:
             min_connections: Minimum number of pooled connections
             max_connections: Maximum number of pooled connections
         """
-        self.connection_string = connection_string or self._get_connection_string()
+        self._connection_string = connection_string or self._get_connection_string()
         self.pool = self._create_pool(min_connections, max_connections)
 
         # In-memory caches
@@ -55,6 +55,9 @@ class PostgresManager:
         self._themes_by_code: dict[str, Theme] = {}
         self._themes_by_id: dict[int, Theme] = {}
         self._cache_loaded = False
+
+    def __repr__(self) -> str:
+        return f"PostgresManager(pool_size={self.pool.minconn}-{self.pool.maxconn})"
 
     def _get_connection_string(self) -> str:
         """
@@ -125,7 +128,7 @@ class PostgresManager:
         return pool.SimpleConnectionPool(
             min_conn,
             max_conn,
-            self.connection_string,
+            self._connection_string,
         )
 
     def get_connection(self) -> extensions.connection:

--- a/tests/unit/test_dag_variable_validation.py
+++ b/tests/unit/test_dag_variable_validation.py
@@ -1,0 +1,44 @@
+"""Validates that all DAG files use Variable.get with default_var."""
+
+import ast
+from pathlib import Path
+
+
+DAGS_DIR = Path(__file__).resolve().parent.parent.parent / "dags"
+
+SCRAPE_DAGS = [
+    DAGS_DIR / "scrape_agencies.py",
+    DAGS_DIR / "scrape_ebc.py",
+]
+
+
+def _find_variable_get_calls(filepath: Path) -> list[ast.Call]:
+    """Find all Variable.get() calls in a Python file via AST."""
+    source = filepath.read_text()
+    tree = ast.parse(source)
+    calls = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Attribute) and func.attr == "get":
+            if isinstance(func.value, ast.Name) and func.value.id == "Variable":
+                calls.append(node)
+    return calls
+
+
+def _has_default_var(call: ast.Call) -> bool:
+    """Check if a Variable.get() call has the default_var keyword argument."""
+    return any(kw.arg == "default_var" for kw in call.keywords)
+
+
+def test_scrape_dags_variable_get_has_default_var():
+    """All Variable.get() calls in scrape DAGs must have default_var."""
+    for dag_file in SCRAPE_DAGS:
+        assert dag_file.exists(), f"{dag_file} not found"
+        calls = _find_variable_get_calls(dag_file)
+        assert len(calls) > 0, f"No Variable.get() calls found in {dag_file.name}"
+        for call in calls:
+            assert _has_default_var(call), (
+                f"{dag_file.name}:{call.lineno} — Variable.get() missing default_var"
+            )

--- a/tests/unit/test_health_checks.py
+++ b/tests/unit/test_health_checks.py
@@ -52,6 +52,13 @@ class TestFindConsecutiveFailures:
         result = find_consecutive_failures(mock_conn, threshold=3)
         assert result == []
 
+    def test_query_uses_most_recent_error_not_max(self, mock_cursor_with_rows):
+        """last_error must come from the most recent row (rn=1), not alphabetical MAX."""
+        mock_conn, mock_cursor = mock_cursor_with_rows([])
+        find_consecutive_failures(mock_conn)
+        sql = mock_cursor.execute.call_args[0][0]
+        assert "MAX(error_category) AS last_error" not in sql
+
 
 class TestFindStaleAgencies:
 

--- a/tests/unit/test_postgres_manager_config.py
+++ b/tests/unit/test_postgres_manager_config.py
@@ -30,7 +30,7 @@ class TestGetConnectionString:
         mock_create_pool.return_value = MagicMock()
         manager = PostgresManager()
 
-        assert manager.connection_string == "postgresql://user:pass@localhost/db"
+        assert manager._connection_string == "postgresql://user:pass@localhost/db"
 
     @patch.dict(os.environ, {}, clear=True)
     @patch("govbr_scraper.storage.postgres_manager.PostgresManager._create_pool")
@@ -53,9 +53,9 @@ class TestGetConnectionString:
         manager = PostgresManager()
 
         # Should detect proxy and return localhost with extracted password
-        assert "127.0.0.1" in manager.connection_string
-        assert "destaquesgovbr_app" in manager.connection_string
-        assert manager.connection_string.startswith("postgresql://")
+        assert "127.0.0.1" in manager._connection_string
+        assert "destaquesgovbr_app" in manager._connection_string
+        assert manager._connection_string.startswith("postgresql://")
 
     @patch.dict(os.environ, {}, clear=True)
     @patch("govbr_scraper.storage.postgres_manager.PostgresManager._create_pool")
@@ -78,7 +78,7 @@ class TestGetConnectionString:
         manager = PostgresManager()
 
         # Should return original secret connection string
-        assert manager.connection_string == "postgresql://user:pass@cloudsql-host/db"
+        assert manager._connection_string == "postgresql://user:pass@cloudsql-host/db"
 
     @patch.dict(os.environ, {"DATABASE_URL": "postgresql://custom:custom@custom-host/custom"})
     @patch("govbr_scraper.storage.postgres_manager.PostgresManager._create_pool")
@@ -97,7 +97,7 @@ class TestGetConnectionString:
         manager = PostgresManager()
 
         # Should use env var, not Secret Manager
-        assert manager.connection_string == "postgresql://custom:custom@custom-host/custom"
+        assert manager._connection_string == "postgresql://custom:custom@custom-host/custom"
         # Secret Manager should not have been called
         mock_run.assert_not_called()
 
@@ -110,14 +110,35 @@ class TestGetConnectionString:
             manager = PostgresManager()
 
             # Should strip whitespace
-            assert manager.connection_string == "postgresql://test:test@testhost/testdb"
-            assert not manager.connection_string.startswith(" ")
-            assert not manager.connection_string.endswith(" ")
+            assert manager._connection_string == "postgresql://test:test@testhost/testdb"
+            assert not manager._connection_string.startswith(" ")
+            assert not manager._connection_string.endswith(" ")
 
 
 # =============================================================================
 # Tests for load_cache()
 # =============================================================================
+
+
+class TestCredentialProtection:
+    """Tests that connection string credentials are not exposed."""
+
+    @patch("govbr_scraper.storage.postgres_manager.PostgresManager._create_pool")
+    def test_connection_string_not_in_repr(self, mock_create_pool):
+        """__repr__ must not expose the connection string password."""
+        mock_create_pool.return_value = MagicMock()
+        manager = PostgresManager(connection_string="postgresql://user:s3cret@host/db")
+        representation = repr(manager)
+        assert "s3cret" not in representation
+        assert "connection_string" not in representation
+
+    @patch("govbr_scraper.storage.postgres_manager.PostgresManager._create_pool")
+    def test_connection_string_is_private(self, mock_create_pool):
+        """Connection string should be stored as private attribute."""
+        mock_create_pool.return_value = MagicMock()
+        manager = PostgresManager(connection_string="postgresql://user:pass@host/db")
+        assert hasattr(manager, "_connection_string")
+        assert not hasattr(manager, "connection_string")
 
 
 class TestLoadCache:

--- a/tests/unit/test_postgres_manager_insert.py
+++ b/tests/unit/test_postgres_manager_insert.py
@@ -60,7 +60,7 @@ def pg_manager(mock_pool):
     """PostgresManager with mocked pool."""
     pool_obj, _, _ = mock_pool
     manager = PostgresManager.__new__(PostgresManager)
-    manager.connection_string = "postgresql://test"
+    manager._connection_string = "postgresql://test"
     manager.pool = pool_obj
     manager._agencies_by_key = {}
     manager._agencies_by_id = {}

--- a/tests/unit/test_postgres_manager_url_dedup.py
+++ b/tests/unit/test_postgres_manager_url_dedup.py
@@ -25,7 +25,7 @@ def mock_pool():
 def pg_manager(mock_pool):
     pool_obj, _, _ = mock_pool
     manager = PostgresManager.__new__(PostgresManager)
-    manager.connection_string = "postgresql://test"
+    manager._connection_string = "postgresql://test"
     manager.pool = pool_obj
     manager._agencies_by_key = {}
     manager._agencies_by_id = {}

--- a/tests/unit/test_scrape_manager_monitoring.py
+++ b/tests/unit/test_scrape_manager_monitoring.py
@@ -119,6 +119,27 @@ class TestScrapeManagerMonitoring:
         assert run.error_category is None
 
 
+    @patch("govbr_scraper.scrapers.scrape_manager.WebScraper")
+    @patch("govbr_scraper.scrapers.scrape_manager.load_urls_from_yaml")
+    def test_non_sequential_logs_articles_scraped_as_saved(self, mock_load, mock_ws_cls):
+        """Non-sequential mode must not log articles_saved=0 for successful scrapes."""
+        mock_load.return_value = {"mec": {"url": "https://www.gov.br/mec", "scraper_type": "html", "active": True}}
+        mock_scraper = MagicMock()
+        mock_scraper.scrape_news.return_value = [
+            {"agency": "mec", "title": "Test", "published_at": "2026-01-01", "url": "http://x"},
+            {"agency": "mec", "title": "Test2", "published_at": "2026-01-01", "url": "http://y"},
+        ]
+        mock_ws_cls.return_value = mock_scraper
+
+        manager, storage = self._make_manager()
+        storage.insert.return_value = 2
+        manager.run_scraper(agencies=["mec"], min_date="2026-01-01", max_date="2026-01-01", sequential=False)
+
+        storage.record_scrape_run.assert_called_once()
+        run = storage.record_scrape_run.call_args[0][0]
+        assert run.articles_saved > 0, f"Expected articles_saved > 0, got {run.articles_saved}"
+
+
 class TestScrapeManagerPreprocessing:
     """ScrapeManager data preprocessing and unique ID generation."""
 

--- a/tests/unit/test_structured_log.py
+++ b/tests/unit/test_structured_log.py
@@ -1,9 +1,9 @@
 """Tests for structured logging of scrape results."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from govbr_scraper.models.monitoring import ErrorCategory, ScrapeRunResult
-from govbr_scraper.monitoring.structured_log import log_scrape_result
+from govbr_scraper.monitoring.structured_log import log_scrape_result, record_scrape_run_safe
 
 
 class TestLogScrapeResult:
@@ -60,3 +60,24 @@ class TestLogScrapeResult:
             error_message="Connection timed out",
         )
         mock_bound.error.assert_called_once()
+
+
+class TestRecordScrapeRunSafe:
+
+    def test_delegates_to_storage(self):
+        mock_storage = MagicMock()
+        mock_run = MagicMock()
+        record_scrape_run_safe(mock_storage, mock_run, "mec")
+        mock_storage.record_scrape_run.assert_called_once_with(mock_run)
+
+    def test_swallows_exception(self):
+        mock_storage = MagicMock()
+        mock_storage.record_scrape_run.side_effect = Exception("DB down")
+        record_scrape_run_safe(mock_storage, MagicMock(), "mec")
+
+    @patch("govbr_scraper.monitoring.structured_log.logger")
+    def test_logs_warning_on_failure(self, mock_logger):
+        mock_storage = MagicMock()
+        mock_storage.record_scrape_run.side_effect = Exception("DB down")
+        record_scrape_run_safe(mock_storage, MagicMock(), "mec")
+        mock_logger.warning.assert_called_once()


### PR DESCRIPTION
## Summary

Corrige 3 bugs e implementa 2 melhorias identificados na revisao do PR #28 (monitoramento de falhas do scraper).

### Bug fixes
- **`MAX(error_category)` retornava valor alfabetico** em vez do erro mais recente — corrigido com `FILTER (WHERE rn = 1)` em `health_checks.py` e `monitor_scraping_health.py`
- **`articles_saved=0` no modo non-sequential** — `log_scrape_result()` era chamado sem o parametro, causando falsos positivos em `find_stale_agencies`
- **`Variable.get("scraper_api_url")` sem `default_var`** — `scrape_agencies.py` e `scrape_ebc.py` agora seguem o padrao das DAGs de monitoramento

### Melhorias
- **`record_scrape_run_safe()` extraido** — logica de tracking duplicada 4x em cada manager centralizada em `structured_log.py`
- **Credenciais protegidas em `PostgresManager`** — `connection_string` renomeado para `_connection_string` (privado) com `__repr__` que nao expoe senhas

### Itens descartados (baixo custo/beneficio)
- Instalacao do pacote `govbr_scraper` no Airflow/Composer
- Deduplicacao de queries entre DAGs e `health_checks.py`
- Uso de `PostgresManager` nas DAGs de monitoramento

## Test plan

- [x] Testes unitarios novos para cada correcao (8 testes adicionados)
- [x] Suite completa passando (465 tests, 0 failures)
- [ ] Verificar que DAGs de monitoramento continuam executando corretamente no Composer
- [ ] Verificar que scrape_agencies/scrape_ebc DAGs falham com mensagem clara se `scraper_api_url` nao estiver configurada

Closes #29