### PR TITLE
feat: endpoint /verify/integrity (supersedes #18)

### DIFF
--- a/src/govbr_scraper/api.py
+++ b/src/govbr_scraper/api.py
@@ -108,6 +108,34 @@ def scrape_agencies(req: ScrapeAgenciesRequest):
     return JSONResponse(content=response.model_dump(), status_code=http_status)
 
 
+class VerifyArticle(BaseModel):
+    unique_id: str
+    url: str | None = None
+    image_url: str | None = None
+    content_hash: str | None = None
+    source_etag: str | None = None
+    check_content: bool = False
+
+
+class VerifyRequest(BaseModel):
+    articles: list[VerifyArticle]
+
+
+@app.post("/verify/integrity")
+def verify_integrity(req: VerifyRequest):
+    from govbr_scraper.integrity.service import verify_batch
+
+    logger.info(f"Verificando integridade de {len(req.articles)} artigos")
+
+    try:
+        result = verify_batch([a.model_dump() for a in req.articles])
+    except Exception as e:
+        logger.error(f"Verificação de integridade falhou: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+    return result
+
+
 @app.post("/scrape/ebc", response_model=ScrapeResponse)
 def scrape_ebc(req: ScrapeEBCRequest):
     from govbr_scraper.storage import StorageAdapter

--- a/src/govbr_scraper/api.py
+++ b/src/govbr_scraper/api.py
@@ -10,7 +10,7 @@ import os
 
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
@@ -108,6 +108,28 @@ def scrape_agencies(req: ScrapeAgenciesRequest):
     return JSONResponse(content=response.model_dump(), status_code=http_status)
 
 
+# Allowlist de domínios aceitos pelo /verify/integrity. Mitiga SSRF contra o
+# metadata server do GCP (169.254.169.254) e sondagem da rede interna do Cloud
+# Run. Manter em sincronia com site_urls.yaml (gov.br) e ebc_webscraper.py (EBC).
+_ALLOWED_URL_PREFIXES = (
+    "https://www.gov.br/",
+    "https://agenciabrasil.ebc.com.br/",
+    "https://memoria.ebc.com.br/",
+    "https://tvbrasil.ebc.com.br/",
+)
+
+
+def _validate_allowed_url(value: str | None) -> str | None:
+    if value is None:
+        return value
+    if not any(value.startswith(prefix) for prefix in _ALLOWED_URL_PREFIXES):
+        raise ValueError(
+            "URL fora da allowlist; domínios aceitos: "
+            + ", ".join(p.rstrip("/") for p in _ALLOWED_URL_PREFIXES)
+        )
+    return value
+
+
 class VerifyArticle(BaseModel):
     unique_id: str
     url: str | None = None
@@ -115,6 +137,11 @@ class VerifyArticle(BaseModel):
     content_hash: str | None = None
     source_etag: str | None = None
     check_content: bool = False
+
+    @field_validator("url", "image_url")
+    @classmethod
+    def _check_url_allowlist(cls, value: str | None) -> str | None:
+        return _validate_allowed_url(value)
 
 
 class VerifyRequest(BaseModel):

--- a/src/govbr_scraper/integrity/__init__.py
+++ b/src/govbr_scraper/integrity/__init__.py
@@ -1,0 +1,1 @@
+"""Verificação de integridade de notícias (imagens e conteúdo)."""

--- a/src/govbr_scraper/integrity/checker.py
+++ b/src/govbr_scraper/integrity/checker.py
@@ -1,0 +1,189 @@
+"""Funções puras de verificação de integridade de notícias."""
+
+import hashlib
+import logging
+from datetime import datetime, timezone
+
+import requests
+from bs4 import BeautifulSoup
+
+from govbr_scraper.scrapers.webscraper import DEFAULT_HEADERS
+
+logger = logging.getLogger(__name__)
+
+IMAGE_CHECK_TIMEOUT = 10
+CONTENT_CHECK_TIMEOUT = 15
+
+
+def check_image(image_url: str, timeout: int = IMAGE_CHECK_TIMEOUT) -> dict:
+    """HTTP HEAD na URL da imagem para verificar disponibilidade.
+
+    Args:
+        image_url: URL da imagem a verificar.
+        timeout: Timeout em segundos.
+
+    Returns:
+        Dict com image_status, image_http_code, image_checked_at, image_content_type.
+    """
+    now = datetime.now(timezone.utc).isoformat()
+
+    if not image_url:
+        return {
+            "image_status": "no_image",
+            "image_http_code": None,
+            "image_checked_at": now,
+            "image_content_type": None,
+        }
+
+    try:
+        resp = requests.head(
+            image_url,
+            headers=DEFAULT_HEADERS,
+            timeout=timeout,
+            allow_redirects=True,
+        )
+        content_type = resp.headers.get("content-type", "")
+        is_image = content_type.startswith("image/") or resp.status_code == 200
+
+        if resp.status_code == 200 and is_image:
+            status = "ok"
+        elif 300 <= resp.status_code < 400:
+            status = "redirect"
+        else:
+            status = "broken"
+
+        return {
+            "image_status": status,
+            "image_http_code": resp.status_code,
+            "image_checked_at": now,
+            "image_content_type": content_type,
+        }
+    except requests.exceptions.Timeout:
+        return {
+            "image_status": "timeout",
+            "image_http_code": None,
+            "image_checked_at": now,
+            "image_content_type": None,
+        }
+    except requests.exceptions.RequestException as e:
+        logger.warning(f"Erro ao verificar imagem {image_url}: {e}")
+        return {
+            "image_status": "broken",
+            "image_http_code": None,
+            "image_checked_at": now,
+            "image_content_type": None,
+        }
+
+
+def check_content(
+    source_url: str,
+    stored_hash: str | None = None,
+    stored_etag: str | None = None,
+    timeout: int = CONTENT_CHECK_TIMEOUT,
+) -> dict:
+    """GET condicional na URL fonte para detectar mudanças de conteúdo.
+
+    Usa If-None-Match (ETag) quando disponível para evitar download completo.
+    Compara hash SHA-256 do HTML do corpo da notícia.
+
+    Args:
+        source_url: URL original da notícia.
+        stored_hash: Hash SHA-256 armazenado da última verificação.
+        stored_etag: ETag armazenado da última verificação.
+        timeout: Timeout em segundos.
+
+    Returns:
+        Dict com content_status, content_hash, content_checked_at, source_etag, new_image_url.
+    """
+    now = datetime.now(timezone.utc).isoformat()
+
+    if not source_url:
+        return {
+            "content_status": "error",
+            "content_hash": stored_hash,
+            "content_checked_at": now,
+            "source_etag": stored_etag,
+            "new_image_url": None,
+        }
+
+    headers = dict(DEFAULT_HEADERS)
+    if stored_etag:
+        headers["If-None-Match"] = stored_etag
+
+    try:
+        resp = requests.get(source_url, headers=headers, timeout=timeout)
+
+        if resp.status_code == 304:
+            return {
+                "content_status": "unchanged",
+                "content_hash": stored_hash,
+                "content_checked_at": now,
+                "source_etag": stored_etag,
+                "new_image_url": None,
+            }
+
+        if resp.status_code == 404:
+            return {
+                "content_status": "removed",
+                "content_hash": stored_hash,
+                "content_checked_at": now,
+                "source_etag": None,
+                "new_image_url": None,
+            }
+
+        if resp.status_code != 200:
+            return {
+                "content_status": "error",
+                "content_hash": stored_hash,
+                "content_checked_at": now,
+                "source_etag": stored_etag,
+                "new_image_url": None,
+            }
+
+        # Extrair corpo do artigo e calcular hash
+        soup = BeautifulSoup(resp.content, "html.parser")
+        article_body = soup.find("div", {"id": "content-core"}) or soup.find(
+            "div", class_="content"
+        )
+
+        body_html = str(article_body) if article_body else resp.text
+        new_hash = "sha256:" + hashlib.sha256(body_html.encode("utf-8")).hexdigest()
+
+        # Extrair imagem atual da página
+        new_image_url = None
+        if article_body:
+            first_img = article_body.find("img")
+            if first_img and first_img.get("src"):
+                new_image_url = first_img["src"]
+
+        new_etag = resp.headers.get("etag")
+
+        if stored_hash and new_hash != stored_hash:
+            content_status = "changed"
+        else:
+            content_status = "unchanged"
+
+        return {
+            "content_status": content_status,
+            "content_hash": new_hash,
+            "content_checked_at": now,
+            "source_etag": new_etag,
+            "new_image_url": new_image_url,
+        }
+    except requests.exceptions.Timeout:
+        return {
+            "content_status": "error",
+            "content_hash": stored_hash,
+            "content_checked_at": now,
+            "source_etag": stored_etag,
+            "new_image_url": None,
+        }
+    except requests.exceptions.RequestException as e:
+        logger.warning(f"Erro ao verificar conteúdo {source_url}: {e}")
+        return {
+            "content_status": "error",
+            "content_hash": stored_hash,
+            "content_checked_at": now,
+            "source_etag": stored_etag,
+            "new_image_url": None,
+        }

--- a/src/govbr_scraper/integrity/checker.py
+++ b/src/govbr_scraper/integrity/checker.py
@@ -13,6 +13,8 @@ logger = logging.getLogger(__name__)
 
 IMAGE_CHECK_TIMEOUT = 10
 CONTENT_CHECK_TIMEOUT = 15
+MAX_CONTENT_SIZE = 5 * 1024 * 1024  # 5 MB — limite de download para evitar OOM no Cloud Run
+_CONTENT_CHUNK_SIZE = 65536
 
 
 def check_image(image_url: str, timeout: int = IMAGE_CHECK_TIMEOUT) -> dict:
@@ -43,7 +45,7 @@ def check_image(image_url: str, timeout: int = IMAGE_CHECK_TIMEOUT) -> dict:
             allow_redirects=True,
         )
         content_type = resp.headers.get("content-type", "")
-        is_image = content_type.startswith("image/") or resp.status_code == 200
+        is_image = content_type.startswith("image/")
 
         if resp.status_code == 200 and is_image:
             status = "ok"
@@ -73,6 +75,32 @@ def check_image(image_url: str, timeout: int = IMAGE_CHECK_TIMEOUT) -> dict:
             "image_checked_at": now,
             "image_content_type": None,
         }
+
+
+def _extract_article_html(soup: BeautifulSoup):
+    """Localiza o corpo do artigo no DOM.
+
+    Espelha o seletor usado por ``WebScraper.get_article_content`` em produção
+    (`div#content`) e adiciona fallback para Volto/Plone 6 antes de desistir.
+
+    Retorna o elemento BeautifulSoup ou ``None`` se não for possível localizar
+    um corpo confiável — o chamador deve tratar ``None`` como ``error`` em vez
+    de hashear a página inteira, que contém header/footer variáveis e produz
+    falso positivo ``changed`` permanente.
+    """
+    article_body = soup.find("div", id="content")
+    if article_body:
+        return article_body
+
+    # Volto / Plone 6 (SPA). O scraper de produção consome API REST para essas
+    # agências em plone6_api_scraper.py, mas tentar o DOM é um fallback barato.
+    main = soup.find("main", id="main-content")
+    if main:
+        article = main.find("article")
+        if article:
+            return article
+
+    return None
 
 
 def check_content(
@@ -111,9 +139,10 @@ def check_content(
         headers["If-None-Match"] = stored_etag
 
     try:
-        resp = requests.get(source_url, headers=headers, timeout=timeout)
+        resp = requests.get(source_url, headers=headers, timeout=timeout, stream=True)
 
         if resp.status_code == 304:
+            resp.close()
             return {
                 "content_status": "unchanged",
                 "content_hash": stored_hash,
@@ -123,6 +152,7 @@ def check_content(
             }
 
         if resp.status_code == 404:
+            resp.close()
             return {
                 "content_status": "removed",
                 "content_hash": stored_hash,
@@ -132,6 +162,7 @@ def check_content(
             }
 
         if resp.status_code != 200:
+            resp.close()
             return {
                 "content_status": "error",
                 "content_hash": stored_hash,
@@ -140,25 +171,61 @@ def check_content(
                 "new_image_url": None,
             }
 
-        # Extrair corpo do artigo e calcular hash
-        soup = BeautifulSoup(resp.content, "html.parser")
-        article_body = soup.find("div", {"id": "content-core"}) or soup.find(
-            "div", class_="content"
-        )
+        # Download limitado para evitar OOM (5MB). Páginas gov.br típicas
+        # pesam <500KB; exceder o limite indica payload anômalo → error.
+        chunks = bytearray()
+        oversize = False
+        for chunk in resp.iter_content(chunk_size=_CONTENT_CHUNK_SIZE):
+            if not chunk:
+                continue
+            chunks.extend(chunk)
+            if len(chunks) > MAX_CONTENT_SIZE:
+                oversize = True
+                break
+        resp.close()
 
-        body_html = str(article_body) if article_body else resp.text
+        if oversize:
+            logger.warning(
+                f"Conteúdo de {source_url} excedeu {MAX_CONTENT_SIZE} bytes — abortado"
+            )
+            return {
+                "content_status": "error",
+                "content_hash": stored_hash,
+                "content_checked_at": now,
+                "source_etag": stored_etag,
+                "new_image_url": None,
+            }
+
+        body_bytes = bytes(chunks)
+        soup = BeautifulSoup(body_bytes, "html.parser")
+        article_body = _extract_article_html(soup)
+
+        if article_body is None:
+            logger.warning(f"Corpo do artigo não encontrado em {source_url}")
+            return {
+                "content_status": "error",
+                "content_hash": stored_hash,
+                "content_checked_at": now,
+                "source_etag": stored_etag,
+                "new_image_url": None,
+            }
+
+        body_html = str(article_body)
         new_hash = "sha256:" + hashlib.sha256(body_html.encode("utf-8")).hexdigest()
 
-        # Extrair imagem atual da página
         new_image_url = None
-        if article_body:
-            first_img = article_body.find("img")
-            if first_img and first_img.get("src"):
-                new_image_url = first_img["src"]
+        first_img = article_body.find("img")
+        if first_img and first_img.get("src"):
+            new_image_url = first_img["src"]
 
         new_etag = resp.headers.get("etag")
 
-        if stored_hash and new_hash != stored_hash:
+        if stored_hash is None:
+            # Primeira verificação: estabelece baseline, não conclui nada sobre
+            # mudança. Tratar como "unchanged" inflaria métricas e mascararia
+            # artigos sem histórico.
+            content_status = "baseline"
+        elif new_hash != stored_hash:
             content_status = "changed"
         else:
             content_status = "unchanged"

--- a/src/govbr_scraper/integrity/service.py
+++ b/src/govbr_scraper/integrity/service.py
@@ -1,0 +1,126 @@
+"""Orquestrador de verificação de integridade em batch."""
+
+import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from govbr_scraper.integrity.checker import check_content, check_image
+
+logger = logging.getLogger(__name__)
+
+MAX_WORKERS = 20
+
+
+def _verify_article(article: dict) -> dict:
+    """Verifica integridade de um único artigo.
+
+    Args:
+        article: Dict com unique_id, url, image_url, content_hash, source_etag, check_content.
+
+    Returns:
+        Dict com unique_id e resultados de imagem e conteúdo.
+    """
+    unique_id = article["unique_id"]
+    result = {"unique_id": unique_id}
+
+    # Verificar imagem
+    image_result = check_image(article.get("image_url"))
+    result.update(image_result)
+
+    # Verificar conteúdo (apenas se solicitado)
+    if article.get("check_content"):
+        content_result = check_content(
+            source_url=article.get("url"),
+            stored_hash=article.get("content_hash"),
+            stored_etag=article.get("source_etag"),
+        )
+        result.update(content_result)
+    else:
+        result["content_status"] = "unchecked"
+
+    return result
+
+
+def verify_batch(articles: list[dict]) -> dict:
+    """Verifica integridade de um batch de artigos em paralelo.
+
+    Args:
+        articles: Lista de dicts com unique_id, url, image_url, content_hash,
+                  source_etag, check_content.
+
+    Returns:
+        Dict com results (lista) e summary (contadores).
+    """
+    if not articles:
+        return {"results": [], "summary": _empty_summary()}
+
+    results = []
+    workers = min(MAX_WORKERS, len(articles))
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = {
+            executor.submit(_verify_article, article): article["unique_id"]
+            for article in articles
+        }
+
+        for future in as_completed(futures):
+            uid = futures[future]
+            try:
+                result = future.result()
+                results.append(result)
+            except Exception as e:
+                logger.error(f"Erro verificando {uid}: {e}")
+                results.append({"unique_id": uid, "image_status": "error", "content_status": "error"})
+
+    summary = _compute_summary(results)
+    logger.info(
+        f"Verificação concluída: {summary['total']} artigos, "
+        f"{summary['images_broken']} imagens quebradas, "
+        f"{summary['content_changed']} conteúdos alterados"
+    )
+
+    return {"results": results, "summary": summary}
+
+
+def _empty_summary() -> dict:
+    return {
+        "total": 0,
+        "images_ok": 0,
+        "images_broken": 0,
+        "images_timeout": 0,
+        "images_no_image": 0,
+        "content_unchanged": 0,
+        "content_changed": 0,
+        "content_removed": 0,
+        "content_error": 0,
+        "content_unchecked": 0,
+    }
+
+
+def _compute_summary(results: list[dict]) -> dict:
+    summary = _empty_summary()
+    summary["total"] = len(results)
+
+    for r in results:
+        img = r.get("image_status", "error")
+        if img == "ok":
+            summary["images_ok"] += 1
+        elif img == "broken":
+            summary["images_broken"] += 1
+        elif img == "timeout":
+            summary["images_timeout"] += 1
+        elif img == "no_image":
+            summary["images_no_image"] += 1
+
+        cnt = r.get("content_status", "unchecked")
+        if cnt == "unchanged":
+            summary["content_unchanged"] += 1
+        elif cnt == "changed":
+            summary["content_changed"] += 1
+        elif cnt == "removed":
+            summary["content_removed"] += 1
+        elif cnt == "error":
+            summary["content_error"] += 1
+        elif cnt == "unchecked":
+            summary["content_unchecked"] += 1
+
+    return summary

--- a/src/govbr_scraper/integrity/service.py
+++ b/src/govbr_scraper/integrity/service.py
@@ -1,13 +1,15 @@
 """Orquestrador de verificação de integridade em batch."""
 
 import logging
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError, as_completed
+from datetime import datetime, timezone
 
 from govbr_scraper.integrity.checker import check_content, check_image
 
 logger = logging.getLogger(__name__)
 
 MAX_WORKERS = 20
+DEFAULT_DEADLINE_SECONDS = 100  # < SCRAPER_REQUEST_TIMEOUT (120s) da DAG no data-platform
 
 
 def _verify_article(article: dict) -> dict:
@@ -22,11 +24,14 @@ def _verify_article(article: dict) -> dict:
     unique_id = article["unique_id"]
     result = {"unique_id": unique_id}
 
-    # Verificar imagem
     image_result = check_image(article.get("image_url"))
     result.update(image_result)
 
-    # Verificar conteúdo (apenas se solicitado)
+    # Só incluir chaves de content quando de fato verificamos. Quando
+    # check_content=False, o merge JSONB no data-platform (`features ||
+    # new_features`) preserva o valor anterior; se injetássemos
+    # content_status="unchecked" aqui, sobrescreveríamos um "unchanged"/
+    # "changed" real da execução anterior.
     if article.get("check_content"):
         content_result = check_content(
             source_url=article.get("url"),
@@ -34,18 +39,25 @@ def _verify_article(article: dict) -> dict:
             stored_etag=article.get("source_etag"),
         )
         result.update(content_result)
-    else:
-        result["content_status"] = "unchecked"
 
     return result
 
 
-def verify_batch(articles: list[dict]) -> dict:
+def verify_batch(
+    articles: list[dict],
+    deadline_seconds: float | None = DEFAULT_DEADLINE_SECONDS,
+) -> dict:
     """Verifica integridade de um batch de artigos em paralelo.
 
     Args:
         articles: Lista de dicts com unique_id, url, image_url, content_hash,
                   source_etag, check_content.
+        deadline_seconds: Tempo máximo (segundos) para processar o batch
+                          inteiro. Ao estourar, futures pendentes são
+                          canceladas e marcadas como ``image_status=timeout``.
+                          Default alinhado com o timeout HTTP da DAG Airflow
+                          no data-platform (evita retry do Airflow com workers
+                          órfãos continuando no Cloud Run).
 
     Returns:
         Dict com results (lista) e summary (contadores).
@@ -54,6 +66,7 @@ def verify_batch(articles: list[dict]) -> dict:
         return {"results": [], "summary": _empty_summary()}
 
     results = []
+    pending_ids = {a["unique_id"] for a in articles}
     workers = min(MAX_WORKERS, len(articles))
 
     with ThreadPoolExecutor(max_workers=workers) as executor:
@@ -62,14 +75,41 @@ def verify_batch(articles: list[dict]) -> dict:
             for article in articles
         }
 
-        for future in as_completed(futures):
-            uid = futures[future]
-            try:
-                result = future.result()
-                results.append(result)
-            except Exception as e:
-                logger.error(f"Erro verificando {uid}: {e}")
-                results.append({"unique_id": uid, "image_status": "error", "content_status": "error"})
+        try:
+            for future in as_completed(futures, timeout=deadline_seconds):
+                uid = futures[future]
+                try:
+                    result = future.result()
+                    results.append(result)
+                except Exception as e:
+                    logger.error(f"Erro verificando {uid}: {e}")
+                    results.append(
+                        {
+                            "unique_id": uid,
+                            "image_status": "error",
+                            "content_status": "error",
+                        }
+                    )
+                pending_ids.discard(uid)
+        except FuturesTimeoutError:
+            logger.warning(
+                f"Deadline de {deadline_seconds}s estourado com "
+                f"{len(pending_ids)} artigos pendentes — marcando como timeout"
+            )
+            for future, uid in futures.items():
+                if uid in pending_ids and not future.done():
+                    future.cancel()
+            now = datetime.now(timezone.utc).isoformat()
+            for uid in pending_ids:
+                results.append(
+                    {
+                        "unique_id": uid,
+                        "image_status": "timeout",
+                        "image_http_code": None,
+                        "image_checked_at": now,
+                        "image_content_type": None,
+                    }
+                )
 
     summary = _compute_summary(results)
     logger.info(
@@ -88,11 +128,11 @@ def _empty_summary() -> dict:
         "images_broken": 0,
         "images_timeout": 0,
         "images_no_image": 0,
+        "content_baseline": 0,
         "content_unchanged": 0,
         "content_changed": 0,
         "content_removed": 0,
         "content_error": 0,
-        "content_unchecked": 0,
     }
 
 
@@ -111,8 +151,11 @@ def _compute_summary(results: list[dict]) -> dict:
         elif img == "no_image":
             summary["images_no_image"] += 1
 
-        cnt = r.get("content_status", "unchecked")
-        if cnt == "unchanged":
+        # Artigos sem chave content_status (check_content=False) não contam.
+        cnt = r.get("content_status")
+        if cnt == "baseline":
+            summary["content_baseline"] += 1
+        elif cnt == "unchanged":
             summary["content_unchanged"] += 1
         elif cnt == "changed":
             summary["content_changed"] += 1
@@ -120,7 +163,5 @@ def _compute_summary(results: list[dict]) -> dict:
             summary["content_removed"] += 1
         elif cnt == "error":
             summary["content_error"] += 1
-        elif cnt == "unchecked":
-            summary["content_unchecked"] += 1
 
     return summary

--- a/tests/unit/test_integrity.py
+++ b/tests/unit/test_integrity.py
@@ -1,0 +1,212 @@
+"""Testes unitários para verificação de integridade de notícias."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from govbr_scraper.integrity.checker import check_content, check_image
+from govbr_scraper.integrity.service import verify_batch
+
+
+# --- check_image ---
+
+
+class TestCheckImage:
+    def test_no_image_url(self):
+        result = check_image(None)
+        assert result["image_status"] == "no_image"
+        assert result["image_http_code"] is None
+
+    def test_empty_image_url(self):
+        result = check_image("")
+        assert result["image_status"] == "no_image"
+
+    @patch("govbr_scraper.integrity.checker.requests.head")
+    def test_image_ok(self, mock_head):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.headers = {"content-type": "image/jpeg"}
+        mock_head.return_value = mock_resp
+
+        result = check_image("https://www.gov.br/img.jpg")
+        assert result["image_status"] == "ok"
+        assert result["image_http_code"] == 200
+        assert result["image_content_type"] == "image/jpeg"
+        assert result["image_checked_at"] is not None
+
+    @patch("govbr_scraper.integrity.checker.requests.head")
+    def test_image_404(self, mock_head):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 404
+        mock_resp.headers = {"content-type": "text/html"}
+        mock_head.return_value = mock_resp
+
+        result = check_image("https://www.gov.br/img.jpg")
+        assert result["image_status"] == "broken"
+        assert result["image_http_code"] == 404
+
+    @patch("govbr_scraper.integrity.checker.requests.head")
+    def test_image_timeout(self, mock_head):
+        mock_head.side_effect = requests.exceptions.Timeout()
+
+        result = check_image("https://www.gov.br/img.jpg")
+        assert result["image_status"] == "timeout"
+        assert result["image_http_code"] is None
+
+    @patch("govbr_scraper.integrity.checker.requests.head")
+    def test_image_connection_error(self, mock_head):
+        mock_head.side_effect = requests.exceptions.ConnectionError()
+
+        result = check_image("https://www.gov.br/img.jpg")
+        assert result["image_status"] == "broken"
+
+
+# --- check_content ---
+
+
+class TestCheckContent:
+    def test_no_source_url(self):
+        result = check_content(None)
+        assert result["content_status"] == "error"
+
+    @patch("govbr_scraper.integrity.checker.requests.get")
+    def test_content_304_not_modified(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 304
+        mock_get.return_value = mock_resp
+
+        result = check_content(
+            "https://www.gov.br/noticia",
+            stored_hash="sha256:abc",
+            stored_etag='"etag123"',
+        )
+        assert result["content_status"] == "unchanged"
+        assert result["content_hash"] == "sha256:abc"
+
+    @patch("govbr_scraper.integrity.checker.requests.get")
+    def test_content_404_removed(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 404
+        mock_get.return_value = mock_resp
+
+        result = check_content("https://www.gov.br/noticia")
+        assert result["content_status"] == "removed"
+
+    @patch("govbr_scraper.integrity.checker.requests.get")
+    def test_content_unchanged_same_hash(self, mock_get):
+        html = b'<div id="content-core"><p>Texto da noticia</p></div>'
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.content = html
+        mock_resp.text = html.decode()
+        mock_resp.headers = {}
+        mock_get.return_value = mock_resp
+
+        # Primeiro call para obter o hash
+        result1 = check_content("https://www.gov.br/noticia")
+        assert result1["content_status"] == "unchanged"  # sem stored_hash, sempre unchanged
+        stored_hash = result1["content_hash"]
+
+        # Segundo call com mesmo conteúdo
+        result2 = check_content("https://www.gov.br/noticia", stored_hash=stored_hash)
+        assert result2["content_status"] == "unchanged"
+
+    @patch("govbr_scraper.integrity.checker.requests.get")
+    def test_content_changed_different_hash(self, mock_get):
+        html = b'<div id="content-core"><p>Texto modificado</p></div>'
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.content = html
+        mock_resp.text = html.decode()
+        mock_resp.headers = {"etag": '"new_etag"'}
+        mock_get.return_value = mock_resp
+
+        result = check_content(
+            "https://www.gov.br/noticia",
+            stored_hash="sha256:hash_antigo",
+        )
+        assert result["content_status"] == "changed"
+        assert result["content_hash"].startswith("sha256:")
+        assert result["source_etag"] == '"new_etag"'
+
+    @patch("govbr_scraper.integrity.checker.requests.get")
+    def test_content_extracts_new_image_url(self, mock_get):
+        html = b'<div id="content-core"><img src="https://gov.br/nova.jpg"/><p>Texto</p></div>'
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.content = html
+        mock_resp.text = html.decode()
+        mock_resp.headers = {}
+        mock_get.return_value = mock_resp
+
+        result = check_content("https://www.gov.br/noticia", stored_hash="sha256:old")
+        assert result["new_image_url"] == "https://gov.br/nova.jpg"
+
+    @patch("govbr_scraper.integrity.checker.requests.get")
+    def test_content_timeout(self, mock_get):
+        mock_get.side_effect = requests.exceptions.Timeout()
+
+        result = check_content("https://www.gov.br/noticia")
+        assert result["content_status"] == "error"
+
+
+# --- verify_batch ---
+
+
+class TestVerifyBatch:
+    def test_empty_batch(self):
+        result = verify_batch([])
+        assert result["results"] == []
+        assert result["summary"]["total"] == 0
+
+    @patch("govbr_scraper.integrity.service.check_image")
+    def test_batch_image_only(self, mock_check_image):
+        mock_check_image.return_value = {
+            "image_status": "ok",
+            "image_http_code": 200,
+            "image_checked_at": "2026-01-01T00:00:00Z",
+            "image_content_type": "image/jpeg",
+        }
+
+        articles = [
+            {"unique_id": "abc123", "image_url": "https://gov.br/img.jpg"},
+            {"unique_id": "def456", "image_url": "https://gov.br/img2.jpg"},
+        ]
+        result = verify_batch(articles)
+
+        assert result["summary"]["total"] == 2
+        assert result["summary"]["images_ok"] == 2
+        assert result["summary"]["content_unchecked"] == 2
+        assert len(result["results"]) == 2
+
+    @patch("govbr_scraper.integrity.service.check_content")
+    @patch("govbr_scraper.integrity.service.check_image")
+    def test_batch_with_content_check(self, mock_check_image, mock_check_content):
+        mock_check_image.return_value = {
+            "image_status": "broken",
+            "image_http_code": 404,
+            "image_checked_at": "2026-01-01T00:00:00Z",
+            "image_content_type": None,
+        }
+        mock_check_content.return_value = {
+            "content_status": "changed",
+            "content_hash": "sha256:new",
+            "content_checked_at": "2026-01-01T00:00:00Z",
+            "source_etag": None,
+            "new_image_url": "https://gov.br/nova.jpg",
+        }
+
+        articles = [
+            {
+                "unique_id": "abc123",
+                "url": "https://gov.br/noticia",
+                "image_url": "https://gov.br/img.jpg",
+                "check_content": True,
+            },
+        ]
+        result = verify_batch(articles)
+
+        assert result["summary"]["total"] == 1
+        assert result["summary"]["images_broken"] == 1
+        assert result["summary"]["content_changed"] == 1

--- a/tests/unit/test_integrity.py
+++ b/tests/unit/test_integrity.py
@@ -4,9 +4,24 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
 
-from govbr_scraper.integrity.checker import check_content, check_image
+from govbr_scraper.api import VerifyArticle, app
+from govbr_scraper.integrity.checker import MAX_CONTENT_SIZE, check_content, check_image
 from govbr_scraper.integrity.service import verify_batch
+
+
+def _mock_get_response(body: bytes, status_code: int = 200, headers: dict | None = None):
+    """Builds a MagicMock compatible with requests.get(stream=True)."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = status_code
+    mock_resp.headers = headers or {}
+    # iter_content devolve o body em um único chunk; suficiente para a lógica
+    # de limite de tamanho nos testes.
+    mock_resp.iter_content.return_value = iter([body])
+    mock_resp.close = MagicMock()
+    return mock_resp
 
 
 # --- check_image ---
@@ -45,6 +60,30 @@ class TestCheckImage:
         result = check_image("https://www.gov.br/img.jpg")
         assert result["image_status"] == "broken"
         assert result["image_http_code"] == 404
+
+    @patch("govbr_scraper.integrity.checker.requests.head")
+    def test_image_200_html_is_broken(self, mock_head):
+        # Regressão: antes, is_image ficava True quando status era 200
+        # independentemente do content-type, classificando landing pages HTML
+        # como imagem "ok".
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.headers = {"content-type": "text/html; charset=utf-8"}
+        mock_head.return_value = mock_resp
+
+        result = check_image("https://www.gov.br/")
+        assert result["image_status"] == "broken"
+        assert result["image_http_code"] == 200
+
+    @patch("govbr_scraper.integrity.checker.requests.head")
+    def test_image_redirect(self, mock_head):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 302
+        mock_resp.headers = {"content-type": "text/html"}
+        mock_head.return_value = mock_resp
+
+        result = check_image("https://www.gov.br/img.jpg")
+        assert result["image_status"] == "redirect"
 
     @patch("govbr_scraper.integrity.checker.requests.head")
     def test_image_timeout(self, mock_head):
@@ -94,33 +133,39 @@ class TestCheckContent:
         assert result["content_status"] == "removed"
 
     @patch("govbr_scraper.integrity.checker.requests.get")
-    def test_content_unchanged_same_hash(self, mock_get):
-        html = b'<div id="content-core"><p>Texto da noticia</p></div>'
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.content = html
-        mock_resp.text = html.decode()
-        mock_resp.headers = {}
-        mock_get.return_value = mock_resp
+    def test_content_baseline_on_first_check(self, mock_get):
+        # Primeira verificação (stored_hash=None) não pode concluir
+        # "unchanged" porque não há baseline para comparar. Deve reportar
+        # baseline para que o data-platform persista o hash e compare a partir
+        # da próxima execução.
+        html = b'<div id="content"><p>Texto da noticia</p></div>'
+        mock_get.return_value = _mock_get_response(html, headers={"etag": '"e1"'})
 
-        # Primeiro call para obter o hash
+        result = check_content("https://www.gov.br/noticia")
+        assert result["content_status"] == "baseline"
+        assert result["content_hash"].startswith("sha256:")
+        assert result["source_etag"] == '"e1"'
+
+    @patch("govbr_scraper.integrity.checker.requests.get")
+    def test_content_unchanged_same_hash(self, mock_get):
+        html = b'<div id="content"><p>Texto da noticia</p></div>'
+        mock_get.return_value = _mock_get_response(html)
+
+        # Primeiro call estabelece baseline
         result1 = check_content("https://www.gov.br/noticia")
-        assert result1["content_status"] == "unchanged"  # sem stored_hash, sempre unchanged
+        assert result1["content_status"] == "baseline"
         stored_hash = result1["content_hash"]
 
-        # Segundo call com mesmo conteúdo
+        # Segundo call com mesmo conteúdo precisa de um novo mock (iter_content
+        # é um iterator e se exaure)
+        mock_get.return_value = _mock_get_response(html)
         result2 = check_content("https://www.gov.br/noticia", stored_hash=stored_hash)
         assert result2["content_status"] == "unchanged"
 
     @patch("govbr_scraper.integrity.checker.requests.get")
     def test_content_changed_different_hash(self, mock_get):
-        html = b'<div id="content-core"><p>Texto modificado</p></div>'
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.content = html
-        mock_resp.text = html.decode()
-        mock_resp.headers = {"etag": '"new_etag"'}
-        mock_get.return_value = mock_resp
+        html = b'<div id="content"><p>Texto modificado</p></div>'
+        mock_get.return_value = _mock_get_response(html, headers={"etag": '"new_etag"'})
 
         result = check_content(
             "https://www.gov.br/noticia",
@@ -132,16 +177,57 @@ class TestCheckContent:
 
     @patch("govbr_scraper.integrity.checker.requests.get")
     def test_content_extracts_new_image_url(self, mock_get):
-        html = b'<div id="content-core"><img src="https://gov.br/nova.jpg"/><p>Texto</p></div>'
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.content = html
-        mock_resp.text = html.decode()
-        mock_resp.headers = {}
-        mock_get.return_value = mock_resp
+        html = b'<div id="content"><img src="https://gov.br/nova.jpg"/><p>Texto</p></div>'
+        mock_get.return_value = _mock_get_response(html)
 
         result = check_content("https://www.gov.br/noticia", stored_hash="sha256:old")
         assert result["new_image_url"] == "https://gov.br/nova.jpg"
+
+    @patch("govbr_scraper.integrity.checker.requests.get")
+    def test_content_error_when_body_not_found(self, mock_get):
+        # Agências Volto/Plone 6 ou páginas com DOM inesperado: sem corpo
+        # identificável, reportar error em vez de hashear a página inteira
+        # (header/footer variáveis → falso positivo "changed" permanente).
+        html = b'<html><body><p>Sem divs reconhecidas</p></body></html>'
+        mock_get.return_value = _mock_get_response(html)
+
+        result = check_content("https://www.gov.br/noticia", stored_hash="sha256:old")
+        assert result["content_status"] == "error"
+        assert result["content_hash"] == "sha256:old"
+
+    @patch("govbr_scraper.integrity.checker.requests.get")
+    def test_content_volto_fallback(self, mock_get):
+        html = (
+            b'<html><body><main id="main-content">'
+            b'<article><p>Conteudo Volto</p></article>'
+            b'</main></body></html>'
+        )
+        mock_get.return_value = _mock_get_response(html)
+
+        result = check_content("https://www.gov.br/noticia")
+        assert result["content_status"] == "baseline"
+        assert result["content_hash"].startswith("sha256:")
+
+    @patch("govbr_scraper.integrity.checker.requests.get")
+    def test_content_oversize_body_aborts(self, mock_get):
+        # Simula resposta maior que MAX_CONTENT_SIZE em chunks — o checker
+        # deve abortar e reportar error sem carregar tudo em memória.
+        chunk = b"A" * 65536
+        num_chunks_over_limit = (MAX_CONTENT_SIZE // len(chunk)) + 2
+
+        def chunks():
+            for _ in range(num_chunks_over_limit):
+                yield chunk
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.headers = {}
+        mock_resp.iter_content.return_value = chunks()
+        mock_resp.close = MagicMock()
+        mock_get.return_value = mock_resp
+
+        result = check_content("https://www.gov.br/noticia")
+        assert result["content_status"] == "error"
 
     @patch("govbr_scraper.integrity.checker.requests.get")
     def test_content_timeout(self, mock_get):
@@ -161,7 +247,11 @@ class TestVerifyBatch:
         assert result["summary"]["total"] == 0
 
     @patch("govbr_scraper.integrity.service.check_image")
-    def test_batch_image_only(self, mock_check_image):
+    def test_batch_image_only_omits_content_status(self, mock_check_image):
+        # Regressão: antes, quando check_content=False, o service injetava
+        # content_status="unchecked" no dict, que era persistido no JSONB
+        # via merge `||` e sobrescrevia um "unchanged"/"changed" real da
+        # execução anterior.
         mock_check_image.return_value = {
             "image_status": "ok",
             "image_http_code": 200,
@@ -177,8 +267,11 @@ class TestVerifyBatch:
 
         assert result["summary"]["total"] == 2
         assert result["summary"]["images_ok"] == 2
-        assert result["summary"]["content_unchecked"] == 2
-        assert len(result["results"]) == 2
+        # Chave content_status deve estar ausente para preservar valor anterior
+        for r in result["results"]:
+            assert "content_status" not in r
+        # Summary não deve mais contar "content_unchecked"
+        assert "content_unchecked" not in result["summary"]
 
     @patch("govbr_scraper.integrity.service.check_content")
     @patch("govbr_scraper.integrity.service.check_image")
@@ -210,3 +303,93 @@ class TestVerifyBatch:
         assert result["summary"]["total"] == 1
         assert result["summary"]["images_broken"] == 1
         assert result["summary"]["content_changed"] == 1
+
+    @patch("govbr_scraper.integrity.service.check_content")
+    @patch("govbr_scraper.integrity.service.check_image")
+    def test_batch_counts_baseline(self, mock_check_image, mock_check_content):
+        mock_check_image.return_value = {
+            "image_status": "ok",
+            "image_http_code": 200,
+            "image_checked_at": "2026-01-01T00:00:00Z",
+            "image_content_type": "image/jpeg",
+        }
+        mock_check_content.return_value = {
+            "content_status": "baseline",
+            "content_hash": "sha256:abc",
+            "content_checked_at": "2026-01-01T00:00:00Z",
+            "source_etag": None,
+            "new_image_url": None,
+        }
+
+        articles = [
+            {
+                "unique_id": "new-article",
+                "url": "https://gov.br/noticia",
+                "image_url": "https://gov.br/img.jpg",
+                "check_content": True,
+            },
+        ]
+        result = verify_batch(articles)
+
+        assert result["summary"]["content_baseline"] == 1
+
+
+# --- VerifyArticle SSRF allowlist ---
+
+
+class TestVerifyArticleAllowlist:
+    def test_accepts_gov_br(self):
+        art = VerifyArticle(
+            unique_id="x",
+            url="https://www.gov.br/mec/pt-br/noticias/a",
+            image_url="https://www.gov.br/mec/foo.jpg",
+        )
+        assert art.url.startswith("https://www.gov.br/")
+
+    def test_accepts_ebc(self):
+        VerifyArticle(
+            unique_id="x",
+            url="https://agenciabrasil.ebc.com.br/noticia",
+            image_url="https://tvbrasil.ebc.com.br/img.jpg",
+        )
+
+    def test_allows_null_fields(self):
+        # url e image_url são opcionais
+        art = VerifyArticle(unique_id="x")
+        assert art.url is None
+        assert art.image_url is None
+
+    def test_rejects_gcp_metadata(self):
+        with pytest.raises(ValidationError):
+            VerifyArticle(
+                unique_id="x",
+                image_url="http://169.254.169.254/computeMetadata/v1/",
+            )
+
+    def test_rejects_arbitrary_host(self):
+        with pytest.raises(ValidationError):
+            VerifyArticle(unique_id="x", url="https://evil.com/foo")
+
+    def test_rejects_http_gov_br(self):
+        # Mesmo domínio, sem HTTPS, não deve passar
+        with pytest.raises(ValidationError):
+            VerifyArticle(unique_id="x", url="http://www.gov.br/mec/")
+
+    def test_rejects_subdomain_trick(self):
+        # https://www.gov.br.evil.com/ não começa com "https://www.gov.br/"
+        with pytest.raises(ValidationError):
+            VerifyArticle(unique_id="x", url="https://www.gov.br.evil.com/foo")
+
+
+class TestVerifyIntegrityEndpoint:
+    def test_endpoint_rejects_bad_url_with_422(self):
+        client = TestClient(app)
+        resp = client.post(
+            "/verify/integrity",
+            json={
+                "articles": [
+                    {"unique_id": "bad", "image_url": "http://169.254.169.254/"}
+                ]
+            },
+        )
+        assert resp.status_code == 422


### PR DESCRIPTION
Implementa o endpoint `POST /verify/integrity` para verificação de integridade de notícias, necessário para desbloquear a issue destaquesgovbr/data-platform#68.

## Contexto

A DAG `verify_news_integrity` (PR data-platform#104) está em produção desde março executando a cada 30 min, mas **falha silenciosamente** porque o endpoint do scraper nunca foi mergeado. Esta PR supersede #18 (que ficou sem review por 2 meses) aplicando todas as correções identificadas na review.

## Implementação

**Commit original** (autor: @nitaibezerra, cherry-picked de #18):
- Endpoint `POST /verify/integrity` em `api.py`
- Módulo `integrity/` com `checker.py` (HTTP HEAD em imagens, GET condicional com ETag + SHA-256 em conteúdo) e `service.py` (batch paralelo com ThreadPoolExecutor)
- 16 testes unitários

**Correções aplicadas** (autor: @miguellsfilho):

### Bugs ALTO (bloqueadores de merge)
1. **SSRF**: validação de URL via allowlist (`gov.br` + 3 domínios EBC) no modelo `VerifyArticle`. Mitiga acesso ao metadata server do GCP (`169.254.169.254`) e sondagem de rede interna.
2. **Falso positivo `is_image`**: removida cláusula `or resp.status_code == 200` que classificava landing pages HTML como imagem válida.
3. **Baseline vs unchanged**: primeira verificação (quando `stored_hash=None`) agora retorna `content_status="baseline"` em vez de `"unchanged"`, evitando inflação de métricas.

### Bugs MÉDIO
4. **Timeout descoordenado**: batch aceita `deadline_seconds` (100s default, < 120s da DAG). Ao estourar, cancela futures pendentes e marca como `"timeout"`. Evita workers órfãos no Cloud Run quando Airflow retries.
5. **OOM**: download em stream com limite de 5MB via `iter_content()`. Páginas típicas gov.br pesam <500KB; payloads anômalos são abortados.
6. **Seletores Plone**: trocado `div#content-core` por `div#content` (espelhando o scraper de produção) + fallback para Volto/Plone 6 (`main#main-content > article`). Retorna `error` quando corpo não é encontrado, em vez de hashear a página inteira (header/footer variáveis → falso positivo `changed` permanente).
7. **`content_status` overwrite**: quando `check_content=False`, a chave não é incluída no dict (antes injetava `"unchecked"`). O merge JSONB (`||`) no data-platform preserva valor anterior.

## Testes

✅ 31 testes de integridade passando (100%)  
✅ 516 testes unitários passando (100%)  
✅ Cobertura: api.py 92%, checker.py 94%, service.py 75%

Novos testes incluem:
- 7 testes de allowlist SSRF (aceita gov.br/EBC, rejeita metadata server, hosts arbitrários, HTTP-only, subdomain tricks)
- Regressões: HTML 200 → `image_status="broken"`, primeira verificação → `"baseline"`, body ausente → `"error"`
- OOM: payload >5MB → abortado
- Volto/Plone 6: fallback de seletor

## Deploy e validação

Após merge:
1. Deploy Cloud Run (workflow `deploy.yaml` automático no merge para `main`)
2. Trigger manual da DAG `verify_news_integrity` no Composer
3. Verificar no Postgres: `SELECT news_id, features->'integrity' FROM news_features WHERE features ? 'integrity' ORDER BY updated_at DESC LIMIT 10;`
4. Verificar no Typesense: documentos com `image_broken:true` aparecem para artigos com imagens 404

## Referências

- Issue: destaquesgovbr/data-platform#68
- PR original (superseded): #18
- Review detalhada: https://github.com/destaquesgovbr/scraper/pull/18#issuecomment-4329594590

🤖 Implementação assistida por Claude Code