### PR TITLE
fix: tratar string vazia como None na validação de URL da allowlist SSRF (#45)

### DIFF
--- a/src/govbr_scraper/api.py
+++ b/src/govbr_scraper/api.py
@@ -139,8 +139,8 @@ _ALLOWED_URL_PREFIXES = (
 
 
 def _validate_allowed_url(value: str | None) -> str | None:
-    if value is None:
-        return value
+    if not value:
+        return None
     if not any(value.startswith(prefix) for prefix in _ALLOWED_URL_PREFIXES):
         raise ValueError(
             "URL fora da allowlist; domínios aceitos: "

--- a/tests/unit/test_integrity.py
+++ b/tests/unit/test_integrity.py
@@ -387,6 +387,12 @@ class TestVerifyArticleAllowlist:
         assert art.url is None
         assert art.image_url is None
 
+    def test_allows_empty_string_fields(self):
+        # String vazia no banco deve ser tratada como None
+        art = VerifyArticle(unique_id="x", url="", image_url="")
+        assert art.url is None
+        assert art.image_url is None
+
     def test_rejects_gcp_metadata(self):
         with pytest.raises(ValidationError):
             VerifyArticle(


### PR DESCRIPTION
## Summary

- Corrige 422 persistente na DAG `verify_news_integrity` causado por artigos com `image_url = ""` no banco
- Muda `if value is None` para `if not value` em `_validate_allowed_url`, tratando string vazia como ausência de URL
- Adiciona teste `test_allows_empty_string_fields`

## Test plan

- [x] `poetry run pytest tests/unit/test_integrity.py` — 36/36 passando
- [ ] Após deploy: DAG `verify_news_integrity` executa sem 422
- [ ] Após deploy: task `save_results` executa com `state=success`

Fixes #45