### PR TITLE
fix: migrar 12 agencias para Plone6APIScraper (data-platform#147)

### DIFF
--- a/dags/config/site_urls.yaml
+++ b/dags/config/site_urls.yaml
@@ -23,6 +23,7 @@ agencies:
   aids:
     url: https://www.gov.br/aids/pt-br/assuntos/noticias
     active: true
+    scraper_type: plone6_api
   ana:
     url: https://www.gov.br/ana/pt-br/assuntos/noticias-e-eventos/noticias
     active: true
@@ -47,6 +48,7 @@ agencies:
   anpd:
     url: https://www.gov.br/anpd/pt-br/assuntos/noticias
     active: true
+    scraper_type: plone6_api
   ans:
     url: https://www.gov.br/ans/pt-br/assuntos/noticias
     active: true
@@ -95,6 +97,7 @@ agencies:
   censipam:
     url: https://www.gov.br/censipam/pt-br/central-de-conteudos/noticias
     active: true
+    scraper_type: plone6_api
   cetem:
     url: https://www.gov.br/cetem/pt-br/noticias
     active: true
@@ -176,6 +179,7 @@ agencies:
   esd:
     url: https://www.gov.br/esd/pt-br/central-de-conteudo/noticias
     active: true
+    scraper_type: plone6_api
   esg:
     url: https://www.gov.br/esg/pt-br/centrais-de-conteudo/noticias
     active: true
@@ -193,6 +197,7 @@ agencies:
   florestal:
     url: https://www.gov.br/florestal/pt-br/assuntos/noticias
     active: true
+    scraper_type: plone6_api
   fnde:
     url: https://www.gov.br/fnde/pt-br/assuntos/noticias
     active: true
@@ -206,8 +211,9 @@ agencies:
     url: https://www.gov.br/funarte/pt-br/assuntos/noticias/todas-noticias
     active: true
   fundacentro:
-    url: https://www.gov.br/fundacentro/pt-br/comunicacao/noticias/noticias/ultimas-noticias
+    url: https://www.gov.br/fundacentro/pt-br/comunicacao/noticias
     active: true
+    scraper_type: plone6_api
   fundaj:
     url: https://www.gov.br/fundaj/pt-br/centrais-de-conteudo/noticias-1
     active: true
@@ -284,9 +290,11 @@ agencies:
   inpp:
     url: https://www.gov.br/inpp/pt-br/noticias
     active: true
+    scraper_type: plone6_api
   insa:
     url: https://www.gov.br/insa/pt-br/assuntos/noticias
     active: true
+    scraper_type: plone6_api
   inss:
     url: https://www.gov.br/inss/pt-br/noticias/ultimas-noticias
     active: true
@@ -371,12 +379,14 @@ agencies:
   mulheres:
     url: https://www.gov.br/mulheres/pt-br/central-de-conteudos/noticias
     active: true
+    scraper_type: plone6_api
   museudoindio:
     url: https://www.gov.br/museudoindio/pt-br/assuntos/noticias
     active: true
   museugoeldi:
     url: https://www.gov.br/museugoeldi/pt-br/arquivos/noticias
     active: true
+    scraper_type: plone6_api
   museus:
     url: https://www.gov.br/museus/pt-br/assuntos/noticias
     active: true
@@ -389,6 +399,7 @@ agencies:
   ouvidorias:
     url: https://www.gov.br/ouvidorias/pt-br/assuntos/noticias
     active: true
+    scraper_type: plone6_api
   palmares:
     url: https://www.gov.br/palmares/pt-br/assuntos/noticias
     active: true
@@ -495,8 +506,9 @@ agencies:
     url: https://www.gov.br/trabalho-e-emprego/pt-br/noticias-e-conteudo
     active: true
   transferegov:
-    url: https://www.gov.br/transferegov/pt-br/noticias/noticias/2025
+    url: https://www.gov.br/transferegov/pt-br/noticias
     active: true
+    scraper_type: plone6_api
   transportes:
     url: https://www.gov.br/transportes/pt-br/assuntos/noticias
     active: true

--- a/src/govbr_scraper/scrapers/config/site_urls.yaml
+++ b/src/govbr_scraper/scrapers/config/site_urls.yaml
@@ -23,6 +23,7 @@ agencies:
   aids:
     url: https://www.gov.br/aids/pt-br/assuntos/noticias
     active: true
+    scraper_type: plone6_api
   ana:
     url: https://www.gov.br/ana/pt-br/assuntos/noticias-e-eventos/noticias
     active: true
@@ -47,6 +48,7 @@ agencies:
   anpd:
     url: https://www.gov.br/anpd/pt-br/assuntos/noticias
     active: true
+    scraper_type: plone6_api
   ans:
     url: https://www.gov.br/ans/pt-br/assuntos/noticias
     active: true
@@ -95,6 +97,7 @@ agencies:
   censipam:
     url: https://www.gov.br/censipam/pt-br/central-de-conteudos/noticias
     active: true
+    scraper_type: plone6_api
   cetem:
     url: https://www.gov.br/cetem/pt-br/noticias
     active: true
@@ -176,6 +179,7 @@ agencies:
   esd:
     url: https://www.gov.br/esd/pt-br/central-de-conteudo/noticias
     active: true
+    scraper_type: plone6_api
   esg:
     url: https://www.gov.br/esg/pt-br/centrais-de-conteudo/noticias
     active: true
@@ -193,6 +197,7 @@ agencies:
   florestal:
     url: https://www.gov.br/florestal/pt-br/assuntos/noticias
     active: true
+    scraper_type: plone6_api
   fnde:
     url: https://www.gov.br/fnde/pt-br/assuntos/noticias
     active: true
@@ -206,8 +211,9 @@ agencies:
     url: https://www.gov.br/funarte/pt-br/assuntos/noticias/todas-noticias
     active: true
   fundacentro:
-    url: https://www.gov.br/fundacentro/pt-br/comunicacao/noticias/noticias/ultimas-noticias
+    url: https://www.gov.br/fundacentro/pt-br/comunicacao/noticias
     active: true
+    scraper_type: plone6_api
   fundaj:
     url: https://www.gov.br/fundaj/pt-br/centrais-de-conteudo/noticias-1
     active: true
@@ -284,9 +290,11 @@ agencies:
   inpp:
     url: https://www.gov.br/inpp/pt-br/noticias
     active: true
+    scraper_type: plone6_api
   insa:
     url: https://www.gov.br/insa/pt-br/assuntos/noticias
     active: true
+    scraper_type: plone6_api
   inss:
     url: https://www.gov.br/inss/pt-br/noticias/ultimas-noticias
     active: true
@@ -371,12 +379,14 @@ agencies:
   mulheres:
     url: https://www.gov.br/mulheres/pt-br/central-de-conteudos/noticias
     active: true
+    scraper_type: plone6_api
   museudoindio:
     url: https://www.gov.br/museudoindio/pt-br/assuntos/noticias
     active: true
   museugoeldi:
     url: https://www.gov.br/museugoeldi/pt-br/arquivos/noticias
     active: true
+    scraper_type: plone6_api
   museus:
     url: https://www.gov.br/museus/pt-br/assuntos/noticias
     active: true
@@ -389,6 +399,7 @@ agencies:
   ouvidorias:
     url: https://www.gov.br/ouvidorias/pt-br/assuntos/noticias
     active: true
+    scraper_type: plone6_api
   palmares:
     url: https://www.gov.br/palmares/pt-br/assuntos/noticias
     active: true
@@ -495,8 +506,9 @@ agencies:
     url: https://www.gov.br/trabalho-e-emprego/pt-br/noticias-e-conteudo
     active: true
   transferegov:
-    url: https://www.gov.br/transferegov/pt-br/noticias/noticias/2025
+    url: https://www.gov.br/transferegov/pt-br/noticias
     active: true
+    scraper_type: plone6_api
   transportes:
     url: https://www.gov.br/transportes/pt-br/assuntos/noticias
     active: true

--- a/tests/unit/test_plone6_agency_migration.py
+++ b/tests/unit/test_plone6_agency_migration.py
@@ -1,0 +1,109 @@
+"""
+Testes validando que as 12 agencias migradas na issue data-platform#147
+estao configuradas para usar Plone6APIScraper.
+"""
+import os
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from govbr_scraper.scrapers.plone6_api_scraper import Plone6APIScraper
+from govbr_scraper.scrapers.scrape_manager import ScrapeManager
+from govbr_scraper.scrapers.webscraper import WebScraper
+from govbr_scraper.scrapers.yaml_config import get_config_dir, load_urls_from_yaml
+
+_SCRAPERS_MODULE = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "..",
+    "..",
+    "src",
+    "govbr_scraper",
+    "scrapers",
+    "scrape_manager.py",
+)
+
+MIGRATED_AGENCIES = [
+    "censipam",
+    "inpp",
+    "esd",
+    "transferegov",
+    "fundacentro",
+    "museugoeldi",
+    "aids",
+    "anpd",
+    "florestal",
+    "ouvidorias",
+    "mulheres",
+    "insa",
+]
+
+
+class TestMigratedAgenciesConfig:
+    """Valida que o YAML tem scraper_type=plone6_api para todas as 12 agencias."""
+
+    @pytest.fixture
+    def config_dir(self):
+        return get_config_dir(_SCRAPERS_MODULE)
+
+    @pytest.mark.parametrize("agency", MIGRATED_AGENCIES)
+    def test_agency_has_plone6_api_scraper_type(self, config_dir, agency):
+        """Cada agencia migrada deve ter scraper_type=plone6_api."""
+        result = load_urls_from_yaml(config_dir, "site_urls.yaml", agency=agency)
+        assert result[agency]["scraper_type"] == "plone6_api", (
+            f"{agency} deveria ter scraper_type=plone6_api, "
+            f"mas tem '{result[agency]['scraper_type']}'"
+        )
+
+    def test_transferegov_url_not_year_specific(self, config_dir):
+        """URL do transferegov NAO deve apontar para subfolder de ano."""
+        result = load_urls_from_yaml(config_dir, "site_urls.yaml", agency="transferegov")
+        url = result["transferegov"]["url"]
+        assert "/2025" not in url, (
+            f"URL do transferegov nao deve conter /2025 (ano especifico). Got: {url}"
+        )
+        assert "/2026" not in url, (
+            f"URL do transferegov nao deve conter /2026 (ano especifico). Got: {url}"
+        )
+
+    def test_fundacentro_url_not_ultimas_noticias(self, config_dir):
+        """URL da fundacentro NAO deve apontar para ultimas-noticias (retorna 0 itens na API)."""
+        result = load_urls_from_yaml(config_dir, "site_urls.yaml", agency="fundacentro")
+        url = result["fundacentro"]["url"]
+        assert "ultimas-noticias" not in url, (
+            f"URL da fundacentro nao deve conter 'ultimas-noticias'. Got: {url}"
+        )
+
+
+class TestMigratedAgenciesScraperSelection:
+    """Valida que ScrapeManager instancia Plone6APIScraper para agencias migradas."""
+
+    @pytest.fixture
+    def mock_scrapers(self):
+        with patch.object(WebScraper, "__init__", return_value=None) as mock_ws_init, \
+             patch.object(WebScraper, "scrape_news", return_value=[]) as mock_ws_scrape, \
+             patch.object(Plone6APIScraper, "__init__", return_value=None) as mock_p6_init, \
+             patch.object(Plone6APIScraper, "scrape_news", return_value=[]) as mock_p6_scrape:
+            yield {
+                "ws_init": mock_ws_init,
+                "ws_scrape": mock_ws_scrape,
+                "p6_init": mock_p6_init,
+                "p6_scrape": mock_p6_scrape,
+            }
+
+    @pytest.mark.parametrize("agency", MIGRATED_AGENCIES)
+    def test_scrape_manager_uses_plone6_scraper(self, agency, mock_scrapers):
+        """ScrapeManager deve usar Plone6APIScraper para cada agencia migrada."""
+        storage = MagicMock()
+        storage.get_recent_urls.return_value = set()
+        storage.insert.return_value = 0
+        manager = ScrapeManager(storage)
+
+        manager.run_scraper(
+            agencies=[agency],
+            min_date="2026-05-01",
+            max_date="2026-05-08",
+            sequential=True,
+        )
+
+        mock_scrapers["p6_init"].assert_called_once()
+        mock_scrapers["ws_init"].assert_not_called()

--- a/tests/unit/test_yaml_config.py
+++ b/tests/unit/test_yaml_config.py
@@ -172,7 +172,12 @@ class TestLoadUrlsReturnsConfigDict:
 
     def test_plone6_agencies_have_correct_scraper_type(self):
         """Plone 6 agencies must be configured with scraper_type=plone6_api."""
-        plone6_agencies = ["susep", "patrimonio", "propriedade-intelectual", "pncp"]
+        plone6_agencies = [
+            "susep", "patrimonio", "propriedade-intelectual", "pncp",
+            "censipam", "inpp", "esd", "transferegov", "fundacentro",
+            "museugoeldi", "aids", "anpd", "florestal", "ouvidorias",
+            "mulheres", "insa",
+        ]
         config_dir = get_config_dir(_SCRAPERS_MODULE)
         for agency in plone6_agencies:
             result = load_urls_from_yaml(config_dir, "site_urls.yaml", agency=agency)


### PR DESCRIPTION
## Summary

- Migra 12 agencias de `WebScraper` (HTML/BeautifulSoup) para `Plone6APIScraper` (API REST do Plone)
- Corrige URLs de transferegov e fundacentro que apontavam para paths vazios na API
- Adiciona 26 testes validando a migracao

## Causa raiz

As 12 agencias migraram para **Plone 6/Volto (React SPA)**. O HTML retornado contem apenas um loader JavaScript — o conteudo e renderizado client-side. `BeautifulSoup` nao encontra artigos, levanta `ScrapingError`, e a API retorna 500 para as DAGs.

**Logs reais do Cloud Run (2026-05-11):**
```
Scraping failed for anpd: No articles found on first page of anpd
but response was 283608 bytes.
```

## Solucao

Adicionar `scraper_type: plone6_api` no `site_urls.yaml`. O `ScrapeManager` ja implementa Strategy Pattern que seleciona `Plone6APIScraper` — zero codigo Python novo.

| Agencia | Mudanca |
|---------|---------|
| censipam, inpp, esd, museugoeldi, aids, anpd, florestal, ouvidorias, mulheres, insa | `scraper_type: plone6_api` adicionado |
| transferegov | URL corrigida (`/noticias/noticias/2025` → `/noticias`) + tipo |
| fundacentro | URL corrigida (`/noticias/noticias/ultimas-noticias` → `/comunicacao/noticias`) + tipo |

## Validacao

- API REST do Plone (`++api++/@search`) retorna HTTP 200 com JSON valido para todas as 12 agencias
- Dados recentes confirmados (artigos de maio 2026)
- 554 testes unitarios passando, zero regressoes

## Test plan

- [x] 26 novos testes parametrizados (config + selecao de scraper)
- [x] Teste de sincronizacao YAML (src/ == dags/) passando
- [x] Testes existentes do Plone6APIScraper (33) passando
- [x] Testes do ScrapeManager Strategy Pattern (8) passando
- [x] Suite completa: 554 PASSED
- [ ] Apos deploy: verificar taxa de falha das 12 agencias < 1%

Closes destaquesgovbr/data-platform#147