### PR TITLE
fix: corrigir DAGs verify_news_integrity e monitor_scraping_health (#49)

### DIFF
--- a/dags/monitor_scraping_health.py
+++ b/dags/monitor_scraping_health.py
@@ -151,7 +151,7 @@ def monitor_scraping_health_dag():
     def send_alerts(failures: list[dict], stale: list[dict]):
         """Envia alertas agregados via Telegram (ou loga)."""
         from airflow.models import Variable
-        from notify import send_alert
+        from scraper.notify import send_alert
 
         if not failures and not stale:
             logger.info("Sem alertas para enviar.")

--- a/dags/scraper_coverage_report.py
+++ b/dags/scraper_coverage_report.py
@@ -104,7 +104,7 @@ def scraper_coverage_report_dag():
     def alert_on_low_coverage(report: dict):
         """Alerta se cobertura abaixo do threshold."""
         from airflow.models import Variable
-        from notify import send_alert
+        from scraper.notify import send_alert
 
         min_ratio = float(Variable.get("scraper_min_coverage_ratio", default_var=0.8))
 

--- a/src/govbr_scraper/api.py
+++ b/src/govbr_scraper/api.py
@@ -34,7 +34,7 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
     )
     return JSONResponse(
         status_code=422,
-        content={"detail": errors},
+        content={"detail": [{k: v for k, v in e.items() if k != "ctx"} for e in errors]},
     )
 
 

--- a/src/govbr_scraper/integrity/checker.py
+++ b/src/govbr_scraper/integrity/checker.py
@@ -3,6 +3,7 @@
 import hashlib
 import logging
 from datetime import datetime, timezone
+from urllib.parse import urljoin
 
 import requests
 from bs4 import BeautifulSoup
@@ -216,7 +217,8 @@ def check_content(
         new_image_url = None
         first_img = article_body.find("img")
         if first_img and first_img.get("src"):
-            new_image_url = first_img["src"]
+            img_src = first_img["src"]
+            new_image_url = urljoin(source_url, img_src) if not img_src.startswith("http") else img_src
 
         new_etag = resp.headers.get("etag")
 

--- a/src/govbr_scraper/scrapers/webscraper.py
+++ b/src/govbr_scraper/scrapers/webscraper.py
@@ -5,6 +5,7 @@ import re
 import time
 from datetime import date, datetime, timezone, timedelta
 from typing import Dict, List, Optional, Tuple
+from urllib.parse import urljoin
 
 import requests
 from bs4 import BeautifulSoup
@@ -838,7 +839,7 @@ class WebScraper:
             category = self._extract_category_from_article_page(soup)
 
             # Extract image before cleaning
-            image_url = self._extract_image_url(article_body)
+            image_url = self._extract_image_url(article_body, article_url=url)
 
             # Extract datetimes from already-fetched soup (avoid redundant HTTP request)
             published_dt = self._extract_datetime_from_jsonld(soup)
@@ -883,15 +884,23 @@ class WebScraper:
 
         return article_body
 
-    def _extract_image_url(self, article_body) -> Optional[str]:
+    def _extract_image_url(self, article_body, article_url: str = "") -> Optional[str]:
         """
-        Extract the first image URL from article body.
+        Extract the first image URL from article body, absolutizing relative paths.
 
         :param article_body: BeautifulSoup element
-        :return: Image URL or None
+        :param article_url: The article URL used as base for relative path resolution
+        :return: Absolute image URL or None
         """
         first_img = article_body.find("img")
-        return first_img["src"] if first_img else None
+        if not first_img:
+            return None
+        img_src = first_img.get("src")
+        if not img_src:
+            return None
+        if not img_src.startswith("http"):
+            return urljoin(article_url, img_src)
+        return img_src
 
     def _clean_html_with_validation(self, article_body, url: str, editorial_lead: Optional[str] = None, subtitle: Optional[str] = None):
         """

--- a/tests/unit/test_dag_monitor_health.py
+++ b/tests/unit/test_dag_monitor_health.py
@@ -31,10 +31,18 @@ def _make_airflow_mocks():
     mock_models = MagicMock()
     mock_models.Variable = mock_variable
 
+    mock_notify = MagicMock()
+    mock_notify.send_alert = MagicMock(return_value=True)
+
+    mock_scraper_pkg = MagicMock()
+    mock_scraper_pkg.notify = mock_notify
+
     return {
         "airflow": MagicMock(),
         "airflow.decorators": mock_decorators,
         "airflow.models": mock_models,
+        "scraper": mock_scraper_pkg,
+        "scraper.notify": mock_notify,
     }
 
 
@@ -190,3 +198,28 @@ class TestAlertMessageFormatting:
         failures = []
         stale = []
         assert not failures and not stale
+
+
+class TestSendAlertsTask:
+    """Tests for the send_alerts task importing scraper.notify correctly."""
+
+    def test_send_alerts_imports_from_scraper_notify(self):
+        """send_alerts must import from scraper.notify, not bare notify."""
+        import inspect
+        mod = _load_module()
+        # The fake_task decorator stores the original function
+        # We need to find it among tasks created during module load
+        source = inspect.getsource(mod.monitor_scraping_health_dag)
+        assert "from scraper.notify import send_alert" in source
+
+    def test_module_loads_with_scraper_notify_mock(self):
+        """DAG module must load successfully when scraper.notify is available."""
+        airflow_mocks = _make_airflow_mocks()
+
+        for key in list(sys.modules):
+            if key.startswith("dags.monitor_scraping_health"):
+                del sys.modules[key]
+
+        with patch.dict(sys.modules, airflow_mocks):
+            import dags.monitor_scraping_health as mod
+            assert mod.monitor_scraping_health_dag is not None

--- a/tests/unit/test_integrity.py
+++ b/tests/unit/test_integrity.py
@@ -184,6 +184,17 @@ class TestCheckContent:
         assert result["new_image_url"] == "https://gov.br/nova.jpg"
 
     @patch("govbr_scraper.integrity.checker.requests.get")
+    def test_content_absolutizes_relative_image_url(self, mock_get):
+        html = b'<div id="content"><img src="resolveuid/abc123/@@images/image"/><p>Texto</p></div>'
+        mock_get.return_value = _mock_get_response(html)
+
+        result = check_content(
+            "https://www.gov.br/mec/pt-br/noticias/artigo", stored_hash="sha256:old"
+        )
+        assert result["new_image_url"].startswith("https://")
+        assert "resolveuid" in result["new_image_url"]
+
+    @patch("govbr_scraper.integrity.checker.requests.get")
     def test_content_error_when_body_not_found(self, mock_get):
         # Agências Volto/Plone 6 ou páginas com DOM inesperado: sem corpo
         # identificável, reportar error em vez de hashear a página inteira
@@ -417,12 +428,7 @@ class TestVerifyArticleAllowlist:
 
 class TestVerifyIntegrityEndpoint:
     def test_endpoint_rejects_bad_url_with_422(self, caplog):
-        """Test that validation errors are logged with details.
-
-        Note: The handler is async and returns 422 in production, but TestClient
-        with raise_server_exceptions=False still returns 500 due to Starlette
-        internals. The important behavior (logging) is verified here.
-        """
+        """Validation errors must return 422 with JSON-serializable detail."""
         import logging
         caplog.set_level(logging.WARNING)
 
@@ -436,8 +442,25 @@ class TestVerifyIntegrityEndpoint:
             },
         )
 
-        # Verify validation error was logged with truncated details
-        assert any("Validation error on /verify/integrity" in record.message
-                   for record in caplog.records)
+        assert resp.status_code == 422
+        body = resp.json()
+        assert isinstance(body["detail"], list)
         assert any("169.254.169.254" in record.message
                    for record in caplog.records)
+
+    def test_relative_url_returns_422_not_500(self):
+        """Plone resolveuid relative URLs must return 422, not 500."""
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post(
+            "/verify/integrity",
+            json={
+                "articles": [
+                    {"unique_id": "x", "image_url": "resolveuid/abc123/@@images/image"}
+                ]
+            },
+        )
+
+        assert resp.status_code == 422
+        body = resp.json()
+        assert isinstance(body["detail"], list)
+        assert body["detail"][0]["type"] == "value_error"

--- a/tests/unit/test_webscraper_extraction.py
+++ b/tests/unit/test_webscraper_extraction.py
@@ -471,3 +471,53 @@ class TestExtractTagsFromArticlePage:
         result = scraper._extract_tags_from_article_page(soup)
 
         assert result == []
+
+
+# =============================================================================
+# Tests for _extract_image_url (URL absolutization)
+# =============================================================================
+
+
+class TestExtractImageUrl:
+    """Tests for _extract_image_url with relative URL absolutization."""
+
+    def test_absolute_url_unchanged(self, scraper):
+        html = '<div><img src="https://www.gov.br/img.jpg"/></div>'
+        body = BeautifulSoup(html, "html.parser").div
+        result = scraper._extract_image_url(body, article_url="https://www.gov.br/mec/noticia")
+        assert result == "https://www.gov.br/img.jpg"
+
+    def test_relative_resolveuid_absolutized(self, scraper):
+        html = '<div><img src="resolveuid/6d007f028ca14a1abc427a81fabbf029/@@images/image/Imagem-6C"/></div>'
+        body = BeautifulSoup(html, "html.parser").div
+        result = scraper._extract_image_url(
+            body, article_url="https://www.gov.br/mec/pt-br/noticias/artigo"
+        )
+        assert result.startswith("https://www.gov.br/")
+        assert "resolveuid" in result
+
+    def test_slash_relative_url_absolutized(self, scraper):
+        html = '<div><img src="/mec/images/foto.jpg"/></div>'
+        body = BeautifulSoup(html, "html.parser").div
+        result = scraper._extract_image_url(
+            body, article_url="https://www.gov.br/mec/pt-br/noticias/artigo"
+        )
+        assert result == "https://www.gov.br/mec/images/foto.jpg"
+
+    def test_no_img_returns_none(self, scraper):
+        html = '<div><p>No image here</p></div>'
+        body = BeautifulSoup(html, "html.parser").div
+        result = scraper._extract_image_url(body, article_url="https://www.gov.br/mec/noticia")
+        assert result is None
+
+    def test_img_without_src_returns_none(self, scraper):
+        html = '<div><img alt="no src"/></div>'
+        body = BeautifulSoup(html, "html.parser").div
+        result = scraper._extract_image_url(body, article_url="https://www.gov.br/mec/noticia")
+        assert result is None
+
+    def test_backward_compat_no_article_url(self, scraper):
+        html = '<div><img src="https://www.gov.br/img.jpg"/></div>'
+        body = BeautifulSoup(html, "html.parser").div
+        result = scraper._extract_image_url(body)
+        assert result == "https://www.gov.br/img.jpg"


### PR DESCRIPTION
## Contexto

Duas DAGs falham em 100% das execucoes desde o deploy do PR #40 (allowlist SSRF):

- **`verify_news_integrity`** — artigos com `image_url` relativa do Plone (`resolveuid/...`) sao rejeitados pela allowlist. O `validation_exception_handler` agrava retornando 500 (ValueError nao-serializavel) em vez de 422.
- **`monitor_scraping_health`** — `from notify import send_alert` falha com `ModuleNotFoundError` porque DAGs sao deployadas em `dags/scraper/` e o Airflow so adiciona `dags/` ao sys.path.

## Mudancas

### 1. Fix serialization do validation_exception_handler (`api.py`)

O campo `ctx` dos errors do Pydantic contem `ValueError(...)` que nao e JSON-serializavel. Strip do `ctx` antes de passar ao `JSONResponse`. Resultado: 422 com body JSON valido.

### 2. Fix import path do notify (`monitor_scraping_health.py`, `scraper_coverage_report.py`)

Alterado de `from notify import send_alert` para `from scraper.notify import send_alert`. Funciona porque `dags/scraper/` e um namespace package sob `dags/` (que esta no sys.path do Composer).

### 3. Absolutizar URLs relativas de imagem (`webscraper.py`, `checker.py`)

`_extract_image_url` agora usa `urljoin(article_url, img_src)` para resolver paths relativos como `resolveuid/...` ou `/path/to/img.jpg` contra a URL do artigo. Mesmo fix aplicado em `checker.py` para o campo `new_image_url`.

## Estrategia de testes

- 11 novos testes cobrindo os 3 fixes
- TDD: todos escritos antes da implementacao (RED → GREEN verificado)
- Suite completa: 590 passed, 0 failed

## Pontos de atencao para reviewers

1. **`_extract_image_url` tem param default `article_url=""`** — backward compat para qualquer caller que nao passe o argumento. Na pratica so tem 1 call site (linha 841).
2. **Import `scraper.notify` so funciona no Composer** — em dev local os testes mockam `sys.modules`. O import real so resolve quando deployado no bucket com a estrutura `dags/scraper/`.
3. **Migracao de dados (separada)** — existe um `013_nullify_relative_image_urls.sql` pendente no data-platform para limpar URLs invalidas ja armazenadas. Sera PR separado.

## Trade-offs

- **Strip `ctx` vs `jsonable_encoder`**: `ctx` so contem o objeto ValueError cru, que nao agrega valor para clientes da API. Strip e mais simples e explicito que encoder generico.
- **`urljoin` vs rejeitar relativas**: preferiu-se absolutizar (dado que a URL do artigo e conhecida) em vez de descartar silenciosamente. Isso preserva a informacao da imagem.

## Checklist

- [x] `validation_exception_handler` retorna 422 com JSON valido
- [x] `_extract_image_url` absolutiza URLs relativas
- [x] `checker.py` absolutiza `new_image_url`
- [x] Import `scraper.notify` funciona no layout do Composer
- [x] Todos os testes passam (590/590)
- [x] Sem regressoes