### PR TITLE
fix: migrar 5 agências para Plone6APIScraper (issue #53)

### DIFF
--- a/dags/config/site_urls.yaml
+++ b/dags/config/site_urls.yaml
@@ -205,8 +205,9 @@ agencies:
     url: https://www.gov.br/funag/pt-br/centrais-de-conteudo/noticias
     active: true
   funai:
-    url: https://www.gov.br/funai/pt-br/assuntos/noticias/2025
+    url: https://www.gov.br/funai/pt-br/assuntos/noticias
     active: true
+    scraper_type: plone6_api
   funarte:
     url: https://www.gov.br/funarte/pt-br/assuntos/noticias/todas-noticias
     active: true
@@ -301,6 +302,7 @@ agencies:
   int:
     url: https://www.gov.br/int/pt-br/assuntos/noticias
     active: true
+    scraper_type: plone6_api
   investidor:
     url: https://www.gov.br/pt-br/noticias
     active: false
@@ -309,6 +311,7 @@ agencies:
   iphan:
     url: https://www.gov.br/iphan/pt-br/assuntos/noticias
     active: true
+    scraper_type: plone6_api
   ird:
     url: https://www.gov.br/ird/pt-br/assuntos/noticias
     active: true
@@ -426,6 +429,7 @@ agencies:
   portos-e-aeroportos:
     url: https://www.gov.br/portos-e-aeroportos/pt-br/assuntos/noticias
     active: true
+    scraper_type: plone6_api
   povosindigenas:
     url: https://www.gov.br/povosindigenas/pt-br/assuntos/noticias
     active: true
@@ -433,6 +437,7 @@ agencies:
   previc:
     url: https://www.gov.br/previc/pt-br/noticias
     active: true
+    scraper_type: plone6_api
   previdencia:
     url: https://www.gov.br/previdencia/pt-br/noticias
     active: true

--- a/src/govbr_scraper/scrapers/config/site_urls.yaml
+++ b/src/govbr_scraper/scrapers/config/site_urls.yaml
@@ -205,8 +205,9 @@ agencies:
     url: https://www.gov.br/funag/pt-br/centrais-de-conteudo/noticias
     active: true
   funai:
-    url: https://www.gov.br/funai/pt-br/assuntos/noticias/2025
+    url: https://www.gov.br/funai/pt-br/assuntos/noticias
     active: true
+    scraper_type: plone6_api
   funarte:
     url: https://www.gov.br/funarte/pt-br/assuntos/noticias/todas-noticias
     active: true
@@ -301,6 +302,7 @@ agencies:
   int:
     url: https://www.gov.br/int/pt-br/assuntos/noticias
     active: true
+    scraper_type: plone6_api
   investidor:
     url: https://www.gov.br/pt-br/noticias
     active: false
@@ -309,6 +311,7 @@ agencies:
   iphan:
     url: https://www.gov.br/iphan/pt-br/assuntos/noticias
     active: true
+    scraper_type: plone6_api
   ird:
     url: https://www.gov.br/ird/pt-br/assuntos/noticias
     active: true
@@ -426,6 +429,7 @@ agencies:
   portos-e-aeroportos:
     url: https://www.gov.br/portos-e-aeroportos/pt-br/assuntos/noticias
     active: true
+    scraper_type: plone6_api
   povosindigenas:
     url: https://www.gov.br/povosindigenas/pt-br/assuntos/noticias
     active: true
@@ -433,6 +437,7 @@ agencies:
   previc:
     url: https://www.gov.br/previc/pt-br/noticias
     active: true
+    scraper_type: plone6_api
   previdencia:
     url: https://www.gov.br/previdencia/pt-br/noticias
     active: true

--- a/tests/unit/test_plone6_agency_migration.py
+++ b/tests/unit/test_plone6_agency_migration.py
@@ -23,6 +23,7 @@ _SCRAPERS_MODULE = os.path.join(
 )
 
 MIGRATED_AGENCIES = [
+    # 12 agencias originais (maio 2026, data-platform#147)
     "censipam",
     "inpp",
     "esd",
@@ -35,6 +36,12 @@ MIGRATED_AGENCIES = [
     "ouvidorias",
     "mulheres",
     "insa",
+    # 5 agencias novas (maio 2026, scraper#53)
+    "funai",
+    "previc",
+    "int",
+    "portos-e-aeroportos",
+    "iphan",
 ]
 
 

--- a/tests/unit/test_plone6_agency_migration.py
+++ b/tests/unit/test_plone6_agency_migration.py
@@ -1,6 +1,6 @@
 """
-Testes validando que as 12 agencias migradas na issue data-platform#147
-estao configuradas para usar Plone6APIScraper.
+Testes validando que agencias migradas para Plone6APIScraper estao
+configuradas corretamente (17 agencias: 12 em data-platform#147 + 5 em scraper#53).
 """
 import os
 
@@ -46,7 +46,7 @@ MIGRATED_AGENCIES = [
 
 
 class TestMigratedAgenciesConfig:
-    """Valida que o YAML tem scraper_type=plone6_api para todas as 12 agencias."""
+    """Valida que o YAML tem scraper_type=plone6_api para todas as 17 agencias."""
 
     @pytest.fixture
     def config_dir(self):
@@ -78,6 +78,17 @@ class TestMigratedAgenciesConfig:
         url = result["fundacentro"]["url"]
         assert "ultimas-noticias" not in url, (
             f"URL da fundacentro nao deve conter 'ultimas-noticias'. Got: {url}"
+        )
+
+    def test_funai_url_not_year_specific(self, config_dir):
+        """URL da funai NAO deve apontar para subfolder de ano."""
+        result = load_urls_from_yaml(config_dir, "site_urls.yaml", agency="funai")
+        url = result["funai"]["url"]
+        assert "/2025" not in url, (
+            f"URL da funai nao deve conter /2025 (ano especifico). Got: {url}"
+        )
+        assert "/2026" not in url, (
+            f"URL da funai nao deve conter /2026 (ano especifico). Got: {url}"
         )
 
 


### PR DESCRIPTION
## Resumo

Migração de 5 agências gov.br para usar `Plone6APIScraper` ao invés do scraper HTML padrão. Essas agências migraram para **Plone 6 + Volto (React SPA)** e estavam falhando sistematicamente (256 falhas/24h, 87% do total) pois o conteúdo é renderizado via JavaScript.

## Agências Migradas

| Agência | Artigos Acessíveis | Observação |
|---------|-------------------|------------|
| **funai** | 5.719 | URL corrigida: removido `/2025` para coletar histórico completo |
| **previc** | 627 | - |
| **int** | 377 | - |
| **portos-e-aeroportos** | 1.633 | - |
| **iphan** | 2.350 | - |
| **TOTAL** | **10.706** | - |

## Mudanças

### Configuração (site_urls.yaml)
- Adicionado `scraper_type: plone6_api` para as 5 agências
- Corrigida URL da FUNAI: `https://www.gov.br/funai/pt-br/assuntos/noticias/2025` → `https://www.gov.br/funai/pt-br/assuntos/noticias`
- Arquivos sincronizados: `src/` e `dags/config/`

### Testes
- Atualizado `test_plone6_agency_migration.py` para incluir as 5 novas agências
- Total de agências Plone6 monitoradas: **17** (12 anteriores + 5 novas)

## Validação

### Testes Unitários ✅
```
575 passed, 4 warnings in 16.97s
Coverage: 78%
```

### APIs Reais Validadas ✅

Todas as 5 APIs Plone6 foram testadas e retornam JSON válido:

```bash
# FUNAI: 5.722 artigos
curl "https://www.gov.br/funai/++api++/pt-br/assuntos/noticias/@search?..."

# PREVIC: 628 artigos
curl "https://www.gov.br/previc/++api++/pt-br/noticias/@search?..."

# INT: 377 artigos
curl "https://www.gov.br/int/++api++/pt-br/assuntos/noticias/@search?..."

# PORTOS: 1.635 artigos
curl "https://www.gov.br/portos-e-aeroportos/++api++/pt-br/assuntos/noticias/@search?..."

# IPHAN: 2.355 artigos
curl "https://www.gov.br/iphan/++api++/pt-br/assuntos/noticias/@search?..."
```

### Arquivos Modificados

```
 dags/config/site_urls.yaml                       | 7 ++++++-
 src/govbr_scraper/scrapers/config/site_urls.yaml | 7 ++++++-
 tests/unit/test_plone6_agency_migration.py       | 7 +++++++
 3 files changed, 19 insertions(+), 2 deletions(-)
```

## Impacto Esperado

- **Falhas diárias**: 256/dia → ~0/dia
- **Taxa de sucesso**: 13% → ~100% para essas agências
- **Cobertura geral**: aumento significativo

## Monitoramento Pós-Deploy

Acompanhar nas primeiras 24h:
1. Cloud Run logs: verificar mensagens `Using Plone6APIScraper for {agência}`
2. Airflow DAGs: status SUCCESS para as 5 DAGs
3. PostgreSQL: verificar inserção de notícias recentes
4. DAG `monitor_scraping_health`: confirmar que alertas param

Closes #53