### PR TITLE
Fix type mismatch in UPDATE query for timestamp and array columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ build/
 .venv/
 venv/
 env/
+.python-version
 
 # IDE
 .idea/

--- a/src/govbr_scraper/scrapers/ebc_scrape_manager.py
+++ b/src/govbr_scraper/scrapers/ebc_scrape_manager.py
@@ -1,7 +1,7 @@
 import logging
 import time
 from collections import OrderedDict
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from typing import Any, Dict, List
 
 from govbr_scraper.models.monitoring import classify_error
@@ -228,7 +228,7 @@ class EBCScrapeManager:
                 "image": item.get("image", "").strip(),
                 "video_url": item.get("video_url", "").strip(),
                 "agency": agency,
-                "extracted_at": datetime.now(),
+                "extracted_at": datetime.now(timezone.utc),
             }
 
             # Only add items with essential data

--- a/src/govbr_scraper/storage/postgres_manager.py
+++ b/src/govbr_scraper/storage/postgres_manager.py
@@ -469,9 +469,11 @@ class PostgresManager:
             UPDATE news SET
                 title = v.title, content = v.content, content_hash = v.content_hash,
                 summary = v.summary, image_url = v.image_url, video_url = v.video_url,
-                category = v.category, tags = v.tags, editorial_lead = v.editorial_lead,
-                subtitle = v.subtitle, updated_datetime = v.updated_datetime,
-                extracted_at = v.extracted_at, updated_at = NOW(),
+                category = v.category, tags = v.tags::TEXT[], editorial_lead = v.editorial_lead,
+                subtitle = v.subtitle,
+                updated_datetime = v.updated_datetime::TIMESTAMPTZ,
+                extracted_at = v.extracted_at::TIMESTAMPTZ,
+                updated_at = NOW(),
                 content_embedding = NULL, embedding_generated_at = NULL
             FROM (VALUES %s) AS v(
                 title, content, content_hash, summary, image_url, video_url,

--- a/tests/unit/test_postgres_manager_update.py
+++ b/tests/unit/test_postgres_manager_update.py
@@ -1,0 +1,58 @@
+"""
+Unit tests for PostgresManager._update_existing_articles()
+"""
+
+import pytest
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+from govbr_scraper.models.news import NewsInsert
+
+
+@pytest.fixture
+def sample_update():
+    """Sample update data with timezone-aware datetimes and tags array."""
+    return [
+        (
+            "existing-uid",
+            NewsInsert(
+                unique_id="new-uid",
+                agency_id=1,
+                agency_key="agencia_brasil",
+                agency_name="Agência Brasil",
+                title="Test Article",
+                url="https://agenciabrasil.ebc.com.br/test",
+                content="Test content",
+                content_hash="abc123",
+                tags=["tag1", "tag2"],
+                updated_datetime=datetime(2026, 6, 2, 12, 0, tzinfo=timezone.utc),
+                extracted_at=datetime(2026, 6, 2, 12, 5, tzinfo=timezone.utc),
+                published_at=datetime(2026, 6, 1, 10, 0, tzinfo=timezone.utc),
+                category="Notícias",
+            ),
+        )
+    ]
+
+
+def test_update_query_has_type_casts(pg_manager, mock_pool, sample_update):
+    """UPDATE query must cast tags::TEXT[] and timestamps::TIMESTAMPTZ."""
+    _, _, mock_cursor = mock_pool
+
+    with patch("govbr_scraper.storage.postgres_manager.execute_values") as mock_exec:
+        pg_manager._update_existing_articles(sample_update, mock_cursor)
+
+    sql = mock_exec.call_args[0][1]
+    assert "tags::TEXT[]" in sql
+    assert "updated_datetime::TIMESTAMPTZ" in sql
+    assert "extracted_at::TIMESTAMPTZ" in sql
+
+
+def test_update_empty_list_skips_query(pg_manager, mock_pool):
+    """Empty updates list should not call execute_values."""
+    _, _, mock_cursor = mock_pool
+
+    with patch("govbr_scraper.storage.postgres_manager.execute_values") as mock_exec:
+        result = pg_manager._update_existing_articles([], mock_cursor)
+
+    assert result == []
+    assert not mock_exec.called


### PR DESCRIPTION
## Resumo

Corrige erro de type mismatch no campo `updated_datetime` do PostgreSQL que causava falhas em 158 execuções da DAG `scrape_ebc` nas últimas 72h.

## Problema

O erro ocorria na query de UPDATE em `_update_existing_articles()`:
```
column "updated_datetime" is of type timestamp with time zone but expression is of type text
column "tags" is of type text[] but expression is of type text
```

**Causa raiz:** PostgreSQL infere todos os valores como TEXT quando usa derived tables com `FROM (VALUES %s)`, exigindo casts explícitos para colunas não-text.

## Mudanças

### 1. postgres_manager.py
Adicionados casts explícitos na query de UPDATE:
- `tags = v.tags::TEXT[]`
- `updated_datetime = v.updated_datetime::TIMESTAMPTZ`
- `extracted_at = v.extracted_at::TIMESTAMPTZ`

### 2. ebc_scrape_manager.py
- Importar `timezone` do módulo datetime
- Usar `datetime.now(timezone.utc)` para criar timestamps timezone-aware

## Verificação

✅ **Bug confirmado ativo antes do fix:**
- Último erro: 2026-06-01 16:59:07
- 158 falhas na DAG `scrape_ebc` (últimas 72h)

✅ **Testes:**
- 576 testes unitários passaram
- 25 testes de integração passaram
- Total: 601 testes passaram

## Contexto Técnico

Por que o INSERT funciona mas o UPDATE não?

**INSERT direto:**
```sql
INSERT INTO news (..., updated_datetime, ...) VALUES (..., '2026-05-28T14:30:00-03:00', ...);
```
PostgreSQL conhece os tipos das colunas-alvo e faz cast automático.

**UPDATE com derived table:**
```sql
UPDATE news SET updated_datetime = v.updated_datetime
FROM (VALUES (..., '2026-05-28T14:30:00-03:00', ...)) AS v(..., updated_datetime, ...)
```
PostgreSQL infere `v.updated_datetime` como TEXT, gerando erro ao atribuir a coluna TIMESTAMPTZ.

Closes #52